### PR TITLE
Bobbi cat utils

### DIFF
--- a/BIN/CAT.S.txt
+++ b/BIN/CAT.S.txt
@@ -1,376 +1,246 @@
 NEW
   AUTO 3,1
-				.LIST OFF
-				.OP	65C02
-				.OR	$2000
-				.TF bin/cat
+                                .LIST OFF
+                                .OP     65C02
+                                .OR     $2000
+                                .TF bin/cat
 *--------------------------------------
-				.INB inc/macros.i
-				.INB inc/a2osx.i
-				.INB inc/kernel.i
-				.INB inc/mli.i
-				.INB inc/mli.e.i
+                                .INB inc/macros.i
+                                .INB inc/a2osx.i
+                                .INB inc/kernel.i
+                                .INB inc/mli.i
+                                .INB inc/mli.e.i
 *--------------------------------------
-				.DUMMY
-				.OR ZPBIN
+                                .DUMMY
+                                .OR ZPBIN
 ZS.START
-ZPPtr1			.BS 2
-ZPBufPtr		.BS 2
-ByteIndex		.BS 1
-ArgCount		.BS 1
-FileCount		.BS 1
-bPause			.BS 1
-bPrintAll		.BS 1
-bLineNum		.BS 1
-bSuppressBlankLine	.BS 1
-ArgIndex		.BS 1
-hBuf			.BS 1
-hFile			.BS 1
-LineNum			.BS 2
-bPrintedBlankLine	.BS 1
-ZS.END			.ED	
+ZPPtr1                  .BS 2
+ZPBufPtr                .BS 2
+ByteIndex               .BS 1
+ArgCount                .BS 1
+FileCount               .BS 1
+bPause                  .BS 1
+bDummy                  .BS 1
+bStdout                 .BS 1
+ArgIndex                .BS 1
+hBuf                    .BS 1
+hFile                   .BS 1
+ZS.END                  .ED     
 *--------------------------------------
-*			File Header (16 Bytes)
+*                       File Header (16 Bytes)
 *--------------------------------------
-CS.START		cld
-				jmp (.1,x)
-				.DA #$61				6502,Level 1 (65c02)
-				.DA #1					BIN Layout Version 1
-				.DA #S.PS.F.EVENT		S.PS.F
-				.DA #0
-				.DA CS.END-CS.START		CS
-				.DA DS.END-DS.START		DS
-				.DA #64					SS
-				.DA #ZS.END-ZS.START	Zero Page Size
-				.DA 0
+CS.START                cld
+                        jmp (.1,x)
+                        .DA #$61                        6502,Level 1 (65c02)
+                        .DA #1                          BIN Layout Version 1
+                        .DA #S.PS.F.EVENT               S.PS.F
+                        .DA #0
+                        .DA CS.END-CS.START             CS
+                        .DA DS.END-DS.START             DS
+                        .DA #64                         SS
+                        .DA #ZS.END-ZS.START            Zero Page Size
+                        .DA 0
 *--------------------------------------
 * Relocation Table
 *--------------------------------------
-.1				.DA CS.INIT
-				.DA CS.RUN
-				.DA CS.DOEVENT		
-				.DA	CS.QUIT
-L.MSG.USAGE		.DA MSG.USAGE
-L.MSG.CRLF		.DA MSG.CRLF
-L.MSG.INIT		.DA MSG.INIT
-L.MSG.LINENUM	.DA MSG.LINENUM
-L.MSG.CTRLCHAR	.DA MSG.CTRLCHAR
-L.ASCII			.DA ASCII
-				.DA 0
+.1                              .DA CS.INIT
+                                .DA CS.RUN
+                                .DA CS.DOEVENT          
+                                .DA CS.QUIT
+L.MSG.USAGE                     .DA MSG.USAGE
+L.MSG.CRLF                      .DA MSG.CRLF
+L.MSG.INIT                      .DA MSG.INIT
+                                .DA 0
 *--------------------------------------
-CS.INIT			clc
-				rts
+CS.INIT                         clc
+                                rts
 *--------------------------------------
-CS.RUN			
-.1				inc ArgCount
-				lda ArgCount
-				>SYSCALL ArgV
-				bcs .7
+CS.RUN                  
+.1                              stz bStdout
+                   
+                                inc ArgCount
+                                lda ArgCount
+                                >SYSCALL ArgV
+                                bcs .7
 
-				>STYA ZPPtr1
+                                >STYA ZPPtr1
 
-				lda (ZPPtr1)
-				cmp #'-'
-				bne .4
+                                lda (ZPPtr1)
+                                cmp #'-'
+                                bne .4
 
-				ldy #1 
-				lda (ZPPtr1),y
+                                ldy #1 
+                                lda (ZPPtr1),y
 
-				ldx #OptionList.Cnt-1
-				
-.2				cmp OptionList,x
-				beq .3
+                                ldx #OptionList.Cnt-1
+                                
+.2                              cmp OptionList,x
+                                beq .3
 
-				dex
-				bpl .2
+                                dex
+                                bpl .2
 
-.99				>PUSHW L.MSG.USAGE
-				>PUSHBI 0
-				>SYSCALL PrintF
-				lda #E.SYN
-				sec
-.9				rts
+.99                             >PUSHW L.MSG.USAGE
+                                >PUSHBI 0
+                                >SYSCALL PrintF
+                                lda #E.SYN
+                                sec
+.9                              rts
 
-.3				ldy OptionVars,x
-				lda #$80
-				sta 0,y
-				bra .1
+.3                              ldy OptionVars,x
+                                lda #$80
+                                sta 0,y
+                                bra .1
 
-.4				inc FileCount
-				bra .1					scan for any other args
+.4                              inc FileCount
+                                bra .1                scan for any other args
 
-.7				lda FileCount
-				beq .99
+.7                              lda FileCount
+                                beq .99
 
-				>LDYAI 256
-				>SYSCALL GetMem
-				bcs .9
+                                >LDYAI 256
+                                >SYSCALL GetMem
+                                bcs .9
 
-				>STYA ZPBufPtr
-				stx hBuf
-				
-				ldy #S.PS.hStdOut
-				lda (pPS),y
+                                >STYA ZPBufPtr
+                                stx hBuf
+                                
+                                ldy #S.PS.hStdOut
+                                lda (pPS),y
 
-				tax
-				
-				lsr
-				bcc CS.RUN.LOOP
-				
-				lda Nod.Table.hFD-2,x
-				>SYSCALL GetMemPtr
-				>STYA ZPPtr1
+                                tax
+                                
+                                lsr
+                                bcc CS.RUN.LOOP
+                                
+                                lda Nod.Table.hFD-2,x
+                                >SYSCALL GetMemPtr
+                                >STYA ZPPtr1
 
-				lda (ZPPtr1)
+                                lda (ZPPtr1)
 
-				beq CS.RUN.LOOP
+                                beq CS.RUN.LOOP
 
-				cmp #S.FD.T.PIPE
-				beq CS.RUN.LOOP
-			
-				>PUSHW L.MSG.INIT
-				>PUSHBI 0
-				>SYSCALL PrintF
+                                cmp #S.FD.T.PIPE
+                                beq CS.RUN.LOOP
+
+                                lda #$ff
+                                sta bStdout
+                        
+                                >PUSHW L.MSG.INIT
+                                >PUSHBI 0
+                                >SYSCALL PrintF
 *--------------------------------------
-CS.RUN.LOOP		ldy #S.PS.hStdIn
-				lda (pPS),y
-				>SYSCALL FEOF
-				bcs .90					IO error
+CS.RUN.LOOP                     ldy #S.PS.hStdIn
+                                lda (pPS),y
+                                >SYSCALL FEOF
+                                bcs .90                         IO error
 
-				tay
-				bne .10					no char
+                                tay
+                                bne .10                         no char
 
-				>SYSCALL GetChar
-				bcs .9					IO error
+                                >SYSCALL GetChar
+                                bcs .9                          IO error
 
-				cmp #$03				Ctrl-C
-				beq .9					Abort....
+                                cmp #$03                        Ctrl-C
+                                beq .9                          Abort....
 
-				cmp #$13				Ctrl-S
-				bne .10
+                                cmp #$13                        Ctrl-S
+                                bne .10
 
-				lda bPause
-				eor	#$ff
-				sta bPause
-				bne CS.RUN.LOOP
+                                lda bPause
+                                eor #$ff
+                                sta bPause
+                                bne CS.RUN.LOOP
 
-.10				lda bPause
-				bne CS.RUN.LOOP			Pause...
+.10                             lda bPause
+                                bne CS.RUN.LOOP                 Pause...
 
-.11				lda hFile
-				bne .2
+.11                             lda hFile
+                                bne .2
 
-.1				inc ArgIndex
-				lda ArgIndex
-				>SYSCALL ArgV
-				bcs .99					No more arg...the end!
+.1                              inc ArgIndex
+                                lda ArgIndex
+                                >SYSCALL ArgV
+                                bcs .99                 No more arg...the end!
 
-				>STYA ZPPtr1
-				lda (ZPPtr1)
-				cmp #'-'
-				beq .1					An option, skip...
+                                >STYA ZPPtr1
+                                lda (ZPPtr1)
+                                cmp #'-'
+                                beq .1                  An option, skip...
 
-				>LDYA ZPPtr1
-				jsr CS.RUN.OPEN
-.90				bcs .9
+                                >LDYA ZPPtr1
+                                jsr CS.RUN.OPEN
+.90                             bcs .9
 
-				sta hFile
+                                sta hFile
 
-.2				>PUSHA
-				>PUSHW ZPBufPtr
-				>PUSHWI	254				Leave room for CRLF
-				>SYSCALL FGetS
-				bcs .7
+.2                              lda hFile
+                                >SYSCALL GetC
+                                bcs .7
 
-				jsr CS.RUN.PRINT
-				bcc CS.RUN.LOOP
-				rts
+                                pha
+                                >SYSCALL PutChar
+                                pla
 
-.7				cmp #MLI.E.EOF
-				bne .9
+                                cmp #C.CR
+                                bne CS.RUN.LOOP
 
-				jsr CS.RUN.CLOSE
-				jmp CS.RUN.LOOP
+                                lda bStdout
+                                beq CS.RUN.LOOP
 
-.99				lda #0					Exit with no Error
-.9				sec
-				rts
+                                lda #C.LF
+                                >SYSCALL PutChar
+ 
+                                bra CS.RUN.LOOP
+
+.7                              cmp #MLI.E.EOF
+                                bne .9
+
+                                jsr CS.RUN.CLOSE
+                                jmp CS.RUN.LOOP
+
+.99                             lda #0                    Exit with no Error
+.9                              sec
+                                rts
 *--------------------------------------
-CS.RUN.OPEN		stz bPrintedBlankLine	Reset this flag for the new file
-				>PUSHYA
-				>PUSHBI	O.RDONLY+O.TEXT
-				>PUSHBI S.FI.T.TXT
-				>PUSHWZ				Aux type
-				>SYSCALL FOpen
-				rts
+CS.RUN.OPEN                     >PUSHYA
+                                >PUSHBI O.RDONLY+O.TEXT
+                                >PUSHBI S.FI.T.TXT
+                                >PUSHWZ                         Aux type
+                                >SYSCALL FOpen
+                                rts
 *--------------------------------------
-CS.RUN.PRINT	inc LineNum
-				bne .10
+CS.QUIT                         lda hBuf
+                                beq CS.RUN.CLOSE
+                                >SYSCALL FreeMem
 
-				inc LineNum+1
+CS.RUN.CLOSE                    lda hFile
+                                beq .8
 
-.10				lda bSuppressBlankLine
-				bpl .2
+                                stz hFile
 
-				lda (ZPBufPtr)
-				bne .1					Empty line ?
-
-				lda bPrintedBlankLine
-				bmi .8
-
-				lda #$ff
-				sta bPrintedBlankLine
-				bra .2
-
-.1				stz bPrintedBlankLine
-
-.2				jsr CS.RUN.PRINTNUM
-				bcs .99
-
-				lda bPrintAll
-				bmi .3
-	
-				ldy #$ff
-
-.20				iny
-				lda (ZPBufPtr),y
-				beq .21
-
-				cmp #C.SPACE
-				bcs .20
-
-				lda #C.SPACE
-				sta (ZPBufPtr),y
-				bra .20
-	
-.21				>LDYA ZPBufPtr
-				>SYSCALL PutS
-				rts
-	
-.3				stz ByteIndex
-
-.4				ldy ByteIndex
-				lda (ZPBufPtr),y
-				beq .7
-
-				cmp #C.SPACE
-				bcc .5
-
-				>SYSCALL PutChar
-.99				bcs .9
-
-				bra .62
-
-.8				clc
-				rts
-
-.5				tax
-
-				>LDYA L.ASCII
-				>STYA ZPPtr1
-.6				dex
-				bmi .61
-				lda ZPPtr1
-				sec
-				adc (ZPPtr1)
-				sta ZPPtr1
-				bcc .6
-				inc ZPPtr1+1
-				bra .6
-
-.61				>PUSHW L.MSG.CTRLCHAR
-				>PUSHW ZPPtr1
-				>PUSHBI 2
-				>SYSCALL PrintF
-				bcs .9
-
-.62				inc ByteIndex
-				bne .4
-				
-.7				>PUSHW L.MSG.CRLF
-				>PUSHBI 0
-				>SYSCALL PrintF
-
-.9				rts
+                                >SYSCALL FClose
+.8                              clc
+                                rts
 *--------------------------------------
-CS.RUN.PRINTNUM	clc
-				lda bLineNum
-				bpl .8
-
-				>PUSHW L.MSG.LINENUM
-				>PUSHW LineNum
-				>PUSHBI 2
-				>SYSCALL PrintF
-.8				rts
-*--------------------------------------
-CS.QUIT			lda hBuf
-				beq CS.RUN.CLOSE
-				>SYSCALL FreeMem
-
-CS.RUN.CLOSE	lda hFile
-				beq .8
-
-				stz hFile
-
-				>SYSCALL FClose
-.8				clc
-				rts
-*--------------------------------------
-CS.DOEVENT		sec
-				rts
+CS.DOEVENT                      sec
+                                rts
 *--------------------------------------
 CS.END
 *--------------------------------------
-OptionList		.AS "ANSans"
-OptionList.Cnt	.EQ *-OptionList
-OptionVars		.DA #bPrintAll,#bLineNum,#bSuppressBlankLine,#bPrintAll,#bLineNum,#bSuppressBlankLine
+OptionList              .AS "x"
+OptionList.Cnt          .EQ *-OptionList
+OptionVars              .DA #bDummy
 *--------------------------------------
-MSG.USAGE		.AS "Usage : CAT File1 [File2...]\r\n"
-				.AS "   -A : Show All non printable characters\r\n"
-				.AS "   -N : Number all output lines\r\n"
-				.AS "   -S : Suppress repeated empty output lines"
-MSG.CRLF		.AZ "\r\n"
-MSG.INIT		.AZ "\e[?7h"			Enable Line Wrap
-MSG.LINENUM		.AZ "%5D:"
-MSG.CTRLCHAR	.AZ "[%S]"
+MSG.USAGE               .AS "Usage : CAT File1 [File2...]"
+MSG.CRLF                .AZ "\r\n"
+MSG.INIT                .AZ "\e[?7h"                    Enable Line Wrap
 *--------------------------------------
-ASCII			>PSTR "NUL"
-				>PSTR "SOH"
-				>PSTR "STX"
-				>PSTR "ETX"
-				>PSTR "EOT"
-				>PSTR "ENQ"
-				>PSTR "ACK"
-				>PSTR "BEL"
-				>PSTR "BS"
-				>PSTR "TAB"
-				>PSTR "LF"
-				>PSTR "VT"
-				>PSTR "FF"
-				>PSTR "CR"
-				>PSTR "SO"
-				>PSTR "SI"
-				>PSTR "DLE"
-				>PSTR "DC1"
-				>PSTR "DC2"
-				>PSTR "DC3"
-				>PSTR "DC4"
-				>PSTR "NAK"
-				>PSTR "SYN"
-				>PSTR "ETB"
-				>PSTR "CAN"
-				>PSTR "EM"
-				>PSTR "SUB"
-				>PSTR "ESC"
-				>PSTR "FS"
-				>PSTR "GS"
-				>PSTR "RS"
-				>PSTR "US"
-*--------------------------------------
-				.DUMMY
-				.OR 0
+                                .DUMMY
+                                .OR 0
 DS.START
-DS.END			.ED
+DS.END                  .ED
 *--------------------------------------
 MAN
 SAVE usr/src/bin/cat.s

--- a/BIN/CAT.S.txt
+++ b/BIN/CAT.S.txt
@@ -121,9 +121,6 @@ CS.RUN
 
                                 beq CS.RUN.LOOP
 
-                                cmp #S.FD.T.PIPE
-                                beq CS.RUN.LOOP
-
                                 inc bIsTTY
                         
                                 >PUSHW L.MSG.INIT

--- a/BIN/CAT.S.txt
+++ b/BIN/CAT.S.txt
@@ -21,7 +21,7 @@ ArgCount                .BS 1
 FileCount               .BS 1
 bPause                  .BS 1
 bDummy                  .BS 1
-bStdout                 .BS 1
+bIsTTY                  .BS 1
 ArgIndex                .BS 1
 hBuf                    .BS 1
 hFile                   .BS 1
@@ -56,7 +56,7 @@ CS.INIT                         clc
                                 rts
 *--------------------------------------
 CS.RUN                  
-.1                              stz bStdout
+.1                              stz bIsTTY
                    
                                 inc ArgCount
                                 lda ArgCount
@@ -124,8 +124,7 @@ CS.RUN
                                 cmp #S.FD.T.PIPE
                                 beq CS.RUN.LOOP
 
-                                lda #$ff
-                                sta bStdout
+                                inc bIsTTY
                         
                                 >PUSHW L.MSG.INIT
                                 >PUSHBI 0
@@ -186,7 +185,7 @@ CS.RUN.LOOP                     ldy #S.PS.hStdIn
                                 cmp #C.CR
                                 bne CS.RUN.LOOP
 
-                                lda bStdout
+                                lda bIsTTY
                                 beq CS.RUN.LOOP
 
                                 lda #C.LF

--- a/BIN/DU.S.txt
+++ b/BIN/DU.S.txt
@@ -1,8 +1,5 @@
 NEW
   AUTO 3,1
-*---------------------------------------
-* DU: Disk Usage - Bobbi - June 15, 2021
-*---------------------------------------
                          .LIST OFF
                          .OP 65C02
                          .OR $2000
@@ -30,6 +27,7 @@ hLineBuf                 .BS 1
 ZPLineBuf                .BS 2
 bPass2                   .BS 1
 bDirLevel                .BS 1
+bIsTTY                   .BS 1
 ZS.END
                          .ED
 *--------------------------------------
@@ -74,7 +72,9 @@ CS.INIT                  clc
                          rts
 *--------------------------------------
 CS.RUN              
-.1                       stz bDirLevel
+.1                       stz bIsTTY
+                         jsr CS.RUN.ISATTY
+                         stz bDirLevel
                          >INC.G ArgCount
                          >SYSCALL ArgV
                          bcs .6
@@ -391,10 +391,24 @@ CS.RUN.PrintCwd          >PUSHW L.MSG.CWD
 *--------------------------------------
 CS.RUN.NewLine           lda #C.CR
                          >SYSCALL PutChar
+                         lda bIsTTY
+                         beq .9
                          lda #C.LF
                          >SYSCALL PutChar
-                         clc
-                         rts
+.9                       rts
+*--------------------------------------
+CS.RUN.ISATTY           ldy #S.PS.hStdOut
+                        lda (pPS),y
+                        tax
+                        lsr
+                        bcc .9
+                        lda Nod.Table.hFD-2,x
+                        >SYSCALL GetMemPtr
+                        >STYA ZPPtr1
+                        lda (ZPPtr1)
+                        beq .9
+                        inc bIsTTY
+.9                      rts
 *--------------------------------------
 CS.DOEVENT               sec
                          rts

--- a/BIN/DU.S.txt
+++ b/BIN/DU.S.txt
@@ -72,9 +72,10 @@ CS.INIT                  clc
                          rts
 *--------------------------------------
 CS.RUN              
-.1                       stz bIsTTY
+                         stz bIsTTY
                          jsr CS.RUN.ISATTY
-                         stz bDirLevel
+
+.1                       stz bDirLevel
                          >INC.G ArgCount
                          >SYSCALL ArgV
                          bcs .6

--- a/BIN/LS.S.txt
+++ b/BIN/LS.S.txt
@@ -1,809 +1,828 @@
 NEW
   AUTO 3,1
-				.LIST OFF
-				.OP	65C02
-				.OR	$2000
-				.TF bin/ls
+                                .LIST OFF
+                                .OP     65C02
+                                .OR     $2000
+                                .TF bin/ls
 *--------------------------------------
-				.INB inc/macros.i
-				.INB inc/a2osx.i
-				.INB inc/kernel.i
-				.INB inc/mli.i
-				.INB inc/mli.e.i
+                                .INB inc/macros.i
+                                .INB inc/a2osx.i
+                                .INB inc/kernel.i
+                                .INB inc/mli.i
+                                .INB inc/mli.e.i
 *--------------------------------------
-X.ENTER.SUBDIR	.EQ 1
-X.COPY.TO.DEST	.EQ 0
-X.DELETE.SOURCE	.EQ 0
+X.ENTER.SUBDIR  .EQ 1
+X.COPY.TO.DEST  .EQ 0
+X.DELETE.SOURCE .EQ 0
 *--------------------------------------
-MAX.COL			.EQ 4
+MAX.COL                 .EQ 4
 *--------------------------------------
-				.DUMMY
-				.OR ZPBIN
+                                .DUMMY
+                                .OR ZPBIN
 ZS.START
-ZPPtr1			.BS 2
-ZPPtr2			.BS 2
-ZPFileName		.BS 2
-ZPFileStat		.BS 2
+ZPPtr1                  .BS 2
+ZPPtr2                  .BS 2
+ZPFileName              .BS 2
+ZPFileStat              .BS 2
 
-ZPLineBuf		.BS 2
-ZPPWBuf			.BS 2
+ZPLineBuf               .BS 2
+ZPPWBuf                 .BS 2
 
-ArgCount		.BS 1
+ArgCount                .BS 1
 
-ColCount		.BS 1
-bPass2			.BS 1
+ColCount                .BS 1
+bPass2                  .BS 1
 
-bPause			.BS 1
-bAllmostAll		.BS 1
-bColumn			.BS 1
-bFullPath		.BS 1
-bLong			.BS 1
-bRecurse		.BS 1
+bPause                  .BS 1
+bAllmostAll             .BS 1
+bColumn                 .BS 1
+bFullPath               .BS 1
+bLong                   .BS 1
+bRecurse                .BS 1
+bIsTTY                  .BS 1
 
-
-ZS.END			.ED
+ZS.END                  .ED
 *--------------------------------------
-*			File Header (16 Bytes)
+*                       File Header (16 Bytes)
 *--------------------------------------
-CS.START		cld
-				jmp (.1,x)
-				.DA #$61				6502,Level 1 (65c02)
-				.DA #1					BIN Layout Version 1
-				.DA #0					S.PS.F.EVENT
-				.DA #0
-				.DA CS.END-CS.START		Code Size (without Constants)
-				.DA DS.END-DS.START		Data SegmentSize
-				.DA #64					Stack Size
-				.DA #ZS.END-ZS.START	Zero Page Size
-				.DA 0
+CS.START                cld
+                                jmp (.1,x)
+                                .DA #$61                                6502,Level 1 (65c02)
+                                .DA #1                                  BIN Layout Version 1
+                                .DA #0                                  S.PS.F.EVENT
+                                .DA #0
+                                .DA CS.END-CS.START             Code Size (without Constants)
+                                .DA DS.END-DS.START             Data SegmentSize
+                                .DA #64                                 Stack Size
+                                .DA #ZS.END-ZS.START    Zero Page Size
+                                .DA 0
 *--------------------------------------
 * Relocation Table
 *--------------------------------------
-.1				.DA CS.INIT
-				.DA CS.RUN
-				.DA CS.DOEVENT
-				.DA	CS.QUIT
+.1                              .DA CS.INIT
+                                .DA CS.RUN
+                                .DA CS.DOEVENT
+                                .DA     CS.QUIT
 L.MSG.USAGE     .DA MSG.USAGE
-L.MSG.REG		.DA MSG.REG
-L.MSG.REGEXT	.DA MSG.REGEXT
-L.MSG.DIR		.DA MSG.DIR
-L.MSG.DIREXT	.DA MSG.DIREXT
-L.MSG.BDEV		.DA MSG.BDEV
-L.MSG.BDEVEXT	.DA MSG.BDEVEXT
-L.MSG.ENTER		.DA MSG.ENTER
-L.PRODOS.FT.TXT	.DA PRODOS.FT.TXT
-L.FMT.Date		.DA FMT.Date
-L.FMT.Time		.DA FMT.Time
-L.FMT.string6	.DA FMT.string6
-L.FMT.int16		.DA FMT.int16
-J.CS.RUN.PRINT	.DA CS.RUN.PRINT.REG
-				.DA CS.RUN.PRINT.DIR
-				.DA CS.RUN.PRINT.CDEV
-				.DA CS.RUN.PRINT.BDEV
-				.DA CS.RUN.PRINT.CDEV
-				.DA CS.RUN.PRINT.CDEV
-				.DA CS.RUN.PRINT.CDEV
-				.DA CS.RUN.PRINT.CDEV
-				.DA 0
+L.MSG.REG               .DA MSG.REG
+L.MSG.REGEXT    .DA MSG.REGEXT
+L.MSG.DIR               .DA MSG.DIR
+L.MSG.DIREXT    .DA MSG.DIREXT
+L.MSG.BDEV              .DA MSG.BDEV
+L.MSG.BDEVEXT   .DA MSG.BDEVEXT
+L.MSG.ENTER             .DA MSG.ENTER
+L.PRODOS.FT.TXT .DA PRODOS.FT.TXT
+L.FMT.Date              .DA FMT.Date
+L.FMT.Time              .DA FMT.Time
+L.FMT.string6   .DA FMT.string6
+L.FMT.int16             .DA FMT.int16
+J.CS.RUN.PRINT  .DA CS.RUN.PRINT.REG
+                                .DA CS.RUN.PRINT.DIR
+                                .DA CS.RUN.PRINT.CDEV
+                                .DA CS.RUN.PRINT.BDEV
+                                .DA CS.RUN.PRINT.CDEV
+                                .DA CS.RUN.PRINT.CDEV
+                                .DA CS.RUN.PRINT.CDEV
+                                .DA CS.RUN.PRINT.CDEV
+                                .DA 0
 *--------------------------------------
-CS.INIT			clc
-				rts
+CS.INIT                 clc
+                                rts
 *--------------------------------------
 CS.RUN
-.1				inc ArgCount
-				lda ArgCount
-				>SYSCALL ArgV
-				bcs .6
+                                stz bIsTTY
+                                jsr CS.RUN.ISATTY
 
-				>STYA ZPPtr1
-				lda (ZPPtr1)
-				cmp #'-'
-				bne .4
+.1                              inc ArgCount
+                                lda ArgCount
+                                >SYSCALL ArgV
+                                bcs .6
 
-				ldy #1
-				lda (ZPPtr1),y
+                                >STYA ZPPtr1
+                                lda (ZPPtr1)
+                                cmp #'-'
+                                bne .4
 
-				ldx #OptionVars-OptionList-1
+                                ldy #1
+                                lda (ZPPtr1),y
 
-.2				cmp OptionList,x
-				beq .3
+                                ldx #OptionVars-OptionList-1
 
-				dex
-				bpl .2
+.2                              cmp OptionList,x
+                                beq .3
+
+                                dex
+                                bpl .2
 
                 >PUSHW L.MSG.USAGE
                 >PUSHBI 0
                 >SYSCALL PrintF
 
-				lda #E.SYN
-				sec
-				rts
+                                lda #E.SYN
+                                sec
+                                rts
 
-.3				ldy OptionVars,x
-				lda #$80
-				sta $0,y
-				bra .1
+.3                              ldy OptionVars,x
+                                lda #$80
+                                sta $0,y
+                                bra .1
 
-.4				>LDYA ZPPtr1
-				jsr InitSrcDirYA
-				bcc .1					scan for any other args
+.4                              >LDYA ZPPtr1
+                                jsr InitSrcDirYA
+                                bcc .1                                  scan for any other args
 
-.9				rts
+.9                              rts
 
-.6				>LDA.G index			do we have a Source dir ?
-				bne .8
+.6                              >LDA.G index                    do we have a Source dir ?
+                                bne .8
 
-				ldy #S.PS.hCWD
-				lda (pPS),y
-				>SYSCALL GetMemPtr
-				jsr InitSrcDirYA
-				bcs .9
+                                ldy #S.PS.hCWD
+                                lda (pPS),y
+                                >SYSCALL GetMemPtr
+                                jsr InitSrcDirYA
+                                bcs .9
 
-.8				>PUSHEA.G TIME.SysTime
-				>SYSCALL Time
+.8                              >PUSHEA.G TIME.SysTime
+                                >SYSCALL Time
 
-				>LDYAI S.PW
-				>SYSCALL GetMem
-				bcs .9
+                                >LDYAI S.PW
+                                >SYSCALL GetMem
+                                bcs .9
 
-				>STYA ZPPWBuf
-				txa
-				>STA.G hPWBuf
+                                >STYA ZPPWBuf
+                                txa
+                                >STA.G hPWBuf
 
-				>LDYAI 256
-				>SYSCALL GetMem
-				bcs .9
+                                >LDYAI 256
+                                >SYSCALL GetMem
+                                bcs .9
 
-				>STYA ZPLineBuf
-				txa
+                                >STYA ZPLineBuf
+                                txa
 
-				>STA.G hLineBuf
+                                >STA.G hLineBuf
 *--------------------------------------
-CS.RUN.LOOP		stz bPass2
+CS.RUN.LOOP             stz bPass2
 
-.1				ldy #S.PS.hStdIn
-				lda (pPS),y
-				>SYSCALL FEOF
-				bcs .99					I/O error
+.1                              ldy #S.PS.hStdIn
+                                lda (pPS),y
+                                >SYSCALL FEOF
+                                bcs .99                                 I/O error
 
-				tay
-				bne .2					no char
+                                tay
+                                bne .2                                  no char
 
-				>SYSCALL GetChar
-				cmp #$03				Ctrl-C
-				beq .99					Abort....
+                                >SYSCALL GetChar
+                                cmp #$03                                Ctrl-C
+                                beq .99                                 Abort....
 
-				cmp #$13				Ctrl-S
-				bne .2
+                                cmp #$13                                Ctrl-S
+                                bne .2
 
-				lda bPause
-				eor	#$ff
-				sta bPause
-				bne .1
+                                lda bPause
+                                eor #$ff
+                                sta bPause
+                                bne .1
 
-.2				bit bPause
-				bmi .1
+.2                              bit bPause
+                                bmi .1
 
-				jsr GetEntry
-				bcs .9
+                                jsr GetEntry
+                                bcs .9
 
-				jsr FilterMatch
-				bcs .8					no match, skip....
+                                jsr FilterMatch
+                                bcs .8                                  no match, skip....
 
-				bit bAllmostAll
-				bmi .4
+                                bit bAllmostAll
+                                bmi .4
 
-				lda (ZPFileName)
-				cmp #'.'
-				beq .8
+                                lda (ZPFileName)
+                                cmp #'.'
+                                beq .8
 
-.4				ldy #S.STAT.MODE+1
-				lda (ZPFileStat),y
+.4                              ldy #S.STAT.MODE+1
+                                lda (ZPFileStat),y
 
-				and #$70
-				lsr
-				lsr
-				lsr
-				tax
-				jsr CS.RUN.PRINT.JMP
-				bcs .99
+                                and #$70
+                                lsr
+                                lsr
+                                lsr
+                                tax
+                                jsr CS.RUN.PRINT.JMP
+                                bcs .99
 
-.8				jsr GetNextEntry
-				bcc .1
+.8                              jsr GetNextEntry
+                                bcc .1
 
-				bit bPass2
-				bmi .9
+                                bit bPass2
+                                bmi .9
 
-				jsr ResetSrcDir
-				bcs .99
+                                jsr ResetSrcDir
+                                bcs .99
 
-				dec bPass2
-				bra .1
+                                dec bPass2
+                                bra .1
 
-.9				bit bLong
-				bmi .91
+.9                              bit bLong
+                                bmi .91
 
-				jsr CS.RUN.NewLine
-				bcs .99
+                                jsr CS.RUN.NewLine
+                                bcs .99
 
-.91				jsr LeaveSubDir
-				bcs .98
+.91                             jsr LeaveSubDir
+                                bcs .98
 
-				jsr BasePath..
+                                jsr BasePath..
 
-				jsr CS.RUN.ENTER.MSG
-				bcs .99
+                                jsr CS.RUN.ENTER.MSG
+                                bcs .99
 
-				jsr GetNextEntry
-				jmp CS.RUN.LOOP
+                                jsr GetNextEntry
+                                jmp CS.RUN.LOOP
 
-.98				lda #0
-				sec
-.99				rts
+.98                             lda #0
+                                sec
+.99                             rts
 *--------------------------------------
 CS.RUN.PRINT.JMP
-				jmp (J.CS.RUN.PRINT,x)
+                                jmp (J.CS.RUN.PRINT,x)
 *--------------------------------------
 CS.RUN.PRINT.REG
-				bit bPass2
-				bpl .8
-				
-				bit bLong
-				bmi .1
+                                bit bPass2
+                                bpl .8
+                                
+                                bit bLong
+                                bmi .1
 
-				bit bColumn
-				bmi .23
+                                bit bColumn
+                                bmi .23
 
-				bit bFullPath
-				bpl .22
+                                bit bFullPath
+                                bpl .22
 
-				jsr CS.RUN.PRINT.SRCPATH
+                                jsr CS.RUN.PRINT.SRCPATH
 
-.23				>LDYA ZPFileName
-				>SYSCALL PutS
-				rts
+.23                             >LDYA ZPFileName
+                                >SYSCALL PutS
+                                rts
 
-.22				>PUSHW L.MSG.REG
-				>PUSHW ZPFileName
-				>PUSHBI 2
-				>SYSCALL PrintF
-				bcs .9
+.22                             >PUSHW L.MSG.REG
+                                >PUSHW ZPFileName
+                                >PUSHBI 2
+                                >SYSCALL PrintF
+                                bcs .9
 
-				jmp CS.RUN.UpdateColCnt				
+                                jmp CS.RUN.UpdateColCnt                         
 
-.8				clc
-.9				rts
+.8                              clc
+.9                              rts
 *--------------------------------------
-.1				>PUSHW L.MSG.REGEXT
+.1                              >PUSHW L.MSG.REGEXT
 
-				jsr Mod2CSTR			(2)
+                                jsr Mod2CSTR                    (2)
 
-				jsr CS.RUN.PushUidGid	(4)
+                                jsr CS.RUN.PushUidGid   (4)
 
-				ldy #S.STAT.SIZE+3
-				ldx #4
+                                ldy #S.STAT.SIZE+3
+                                ldx #4
 
-.2				lda (ZPFileStat),y
-				>PUSHA
-				dey
-				dex
-				bne .2					(4)
+.2                              lda (ZPFileStat),y
+                                >PUSHA
+                                dey
+                                dex
+                                bne .2                                  (4)
 
-				jsr CS.RUN.PUSHDATES	(4)
+                                jsr CS.RUN.PUSHDATES    (4)
 
-				ldy #S.STAT.P.TYPE
-				lda (ZPFileStat),y
-				jsr FileType2PSTR
-				>PUSHYA					(2)
+                                ldy #S.STAT.P.TYPE
+                                lda (ZPFileStat),y
+                                jsr FileType2PSTR
+                                >PUSHYA                                 (2)
 
-				ldy #S.STAT.P.AUXTYPE+1
-				lda (ZPFileStat),y
-				>PUSHA
-				dey
-				lda (ZPFileStat),y
-				>PUSHA					(2)
+                                ldy #S.STAT.P.AUXTYPE+1
+                                lda (ZPFileStat),y
+                                >PUSHA
+                                dey
+                                lda (ZPFileStat),y
+                                >PUSHA                                  (2)
 
-				>PUSHW ZPFileName		(2)
+                                >PUSHW ZPFileName               (2)
 
-				>PUSHBI 20
-				>SYSCALL PrintF
-				bcs .9
+                                >PUSHBI 20
+                                >SYSCALL PrintF
+                                bcs .9
 
-				jmp CS.RUN.NewLine.1
+                                jmp CS.RUN.NewLine.1
 *--------------------------------------
 CS.RUN.PRINT.DIR
-				bit bPass2
-				bmi .8
+                                bit bPass2
+                                bmi .8
 
-				bit bLong
-				bmi .4
+                                bit bLong
+                                bmi .4
 
-				bit bColumn
-				bmi .23
+                                bit bColumn
+                                bmi .23
 
-				bit bFullPath
-				bpl .22
+                                bit bFullPath
+                                bpl .22
 
-				jsr CS.RUN.PRINT.SRCPATH
+                                jsr CS.RUN.PRINT.SRCPATH
 
-.23				>LDYA ZPFileName
-				>SYSCALL PutS
-				bcs .9
+.23                             >LDYA ZPFileName
+                                >SYSCALL PutS
+                                bcs .9
 
-				bit bRecurse
-				bpl .8
+                                bit bRecurse
+                                bpl .8
 
-				lda (ZPFileName)
-				cmp #'.'
-				beq .8
+                                lda (ZPFileName)
+                                cmp #'.'
+                                beq .8
 
-				>LDYA ZPFileName
-				jmp EnterSubDirYA
+                                >LDYA ZPFileName
+                                jmp EnterSubDirYA
 
-.8				clc
-.9				rts
+.8                              clc
+.9                              rts
 
-.22				>PUSHW L.MSG.DIR
-				>PUSHW ZPFileName
-				>PUSHBI 2
-				>SYSCALL PrintF
-				bcs .9
+.22                             >PUSHW L.MSG.DIR
+                                >PUSHW ZPFileName
+                                >PUSHBI 2
+                                >SYSCALL PrintF
+                                bcs .9
 
-				ldy #0
+                                ldy #0
 
-.1				iny
-				lda (ZPFileName),y
-				bne .1
+.1                              iny
+                                lda (ZPFileName),y
+                                bne .1
 
-.11				iny
-				cpy #19
-				bcs .2
+.11                             iny
+                                cpy #19
+                                bcs .2
 
-				lda #C.SPACE
-				phy
-				>SYSCALL PutChar
-				ply
-				bcc .11
-				rts
+                                lda #C.SPACE
+                                phy
+                                >SYSCALL PutChar
+                                ply
+                                bcc .11
+                                rts
 
-.2				jsr CS.RUN.UpdateColCnt
-				bcc .5
-				rts
+.2                              jsr CS.RUN.UpdateColCnt
+                                bcc .5
+                                rts
 *--------------------------------------
-.4				>PUSHW L.MSG.DIREXT
+.4                              >PUSHW L.MSG.DIREXT
 
-				jsr Mod2CSTR
+                                jsr Mod2CSTR
 
-				jsr CS.RUN.PushUidGid
-				jsr CS.RUN.PUSHDATES
-				>PUSHW ZPFileName
-				>PUSHBI 12
-				>SYSCALL PrintF
-				bcs .90
+                                jsr CS.RUN.PushUidGid
+                                jsr CS.RUN.PUSHDATES
+                                >PUSHW ZPFileName
+                                >PUSHBI 12
+                                >SYSCALL PrintF
+                                bcs .90
 
-				jsr CS.RUN.NewLine.1
-				bcs .90
+                                jsr CS.RUN.NewLine.1
+                                bcs .90
 
-.5				bit bRecurse
-				bpl .80
+.5                              bit bRecurse
+                                bpl .80
 
-				lda (ZPFileName)
-				cmp #'.'
-				beq .80
+                                lda (ZPFileName)
+                                cmp #'.'
+                                beq .80
 
-				jsr CS.RUN.NewLine
-				bcs .90
+                                jsr CS.RUN.NewLine
+                                bcs .90
 
-				>LDYA ZPFileName
-				jsr EnterSubDirYA
-				bcs .90
+                                >LDYA ZPFileName
+                                jsr EnterSubDirYA
+                                bcs .90
 
-				jmp CS.RUN.ENTER.MSG
+                                jmp CS.RUN.ENTER.MSG
 
-.80				clc
-.90				rts
+.80                             clc
+.90                             rts
 *--------------------------------------
 CS.RUN.PRINT.CDEV
-				clc
-				rts
+                                clc
+                                rts
 *--------------------------------------
 CS.RUN.PRINT.BDEV
-				bit bPass2
-				bmi .8
-				
-				bit bLong
-				bmi .20
+                                bit bPass2
+                                bmi .8
+                                
+                                bit bLong
+                                bmi .20
 
-				bit bColumn
-				bmi .23
+                                bit bColumn
+                                bmi .23
 
-				bit bFullPath
-				bpl .22
+                                bit bFullPath
+                                bpl .22
 
-				jsr CS.RUN.PRINT.SRCPATH
+                                jsr CS.RUN.PRINT.SRCPATH
 
-.23				>LDYA ZPFileName
-				>SYSCALL PutS
-				bcs .9
+.23                             >LDYA ZPFileName
+                                >SYSCALL PutS
+                                bcs .9
 
-				bit bRecurse
-				bpl .8
+                                bit bRecurse
+                                bpl .8
 
-				lda (ZPFileName)
-				cmp #'.'
-				beq .8
+                                lda (ZPFileName)
+                                cmp #'.'
+                                beq .8
 
-				>LDYA ZPFileName
-				jmp EnterSubDirYA
+                                >LDYA ZPFileName
+                                jmp EnterSubDirYA
 
-.8				clc
-.9				rts
+.8                              clc
+.9                              rts
 
-.22				>PUSHW L.MSG.BDEV
-				>PUSHW ZPFileName
-				>PUSHBI 2
-				>SYSCALL PrintF
-				bcs .9
+.22                             >PUSHW L.MSG.BDEV
+                                >PUSHW ZPFileName
+                                >PUSHBI 2
+                                >SYSCALL PrintF
+                                bcs .9
 
-				ldy #0
+                                ldy #0
 
-.1				iny
-				lda (ZPFileName),y
-				bne .1
+.1                              iny
+                                lda (ZPFileName),y
+                                bne .1
 
-.11				iny
-				cpy #19
-				bcs .2
+.11                             iny
+                                cpy #19
+                                bcs .2
 
-				lda #C.SPACE
-				phy
-				>SYSCALL PutChar
-				ply
-				bcc .11
+                                lda #C.SPACE
+                                phy
+                                >SYSCALL PutChar
+                                ply
+                                bcc .11
 
-				rts
+                                rts
 
-.2				jsr CS.RUN.UpdateColCnt
-*				bcc .5
-				rts
+.2                              jsr CS.RUN.UpdateColCnt
+*                               bcc .5
+                                rts
 *--------------------------------------
-.20				>PUSHW L.MSG.BDEVEXT
-				>PUSHW ZPFileName
+.20                             >PUSHW L.MSG.BDEVEXT
+                                >PUSHW ZPFileName
 
-				ldy #S.STAT.P.SLOT
-				>PUSHB (ZPFileStat),y
-				iny						DRIVE
-				>PUSHB (ZPFileStat),y
+                                ldy #S.STAT.P.SLOT
+                                >PUSHB (ZPFileStat),y
+                                iny                                             DRIVE
+                                >PUSHB (ZPFileStat),y
 
-				ldy #S.STAT.BLOCKS+1
-				>PUSHB (ZPFileStat),y
-				dey
-				>PUSHB (ZPFileStat),y
+                                ldy #S.STAT.BLOCKS+1
+                                >PUSHB (ZPFileStat),y
+                                dey
+                                >PUSHB (ZPFileStat),y
 
-				ldy #S.STAT.P.DEVBLOCKS+1
-				>PUSHB (ZPFileStat),y
-				dey
-				>PUSHB (ZPFileStat),y
+                                ldy #S.STAT.P.DEVBLOCKS+1
+                                >PUSHB (ZPFileStat),y
+                                dey
+                                >PUSHB (ZPFileStat),y
 
-				>PUSHBI 8
+                                >PUSHBI 8
 
-				>SYSCALL PrintF
-				bcs .90
+                                >SYSCALL PrintF
+                                bcs .90
 
-				jsr CS.RUN.NewLine.1
-				bcs .90
+                                jsr CS.RUN.NewLine.1
+                                bcs .90
 
-				bit bRecurse
-				bpl .80
+                                bit bRecurse
+                                bpl .80
 
-				>LDYA ZPFileName
-				jsr EnterSubDirYA
-				bcs .90
+                                >LDYA ZPFileName
+                                jsr EnterSubDirYA
+                                bcs .90
 
-				jmp CS.RUN.ENTER.MSG
+                                jmp CS.RUN.ENTER.MSG
 
-.80				clc
-.90				rts
+.80                             clc
+.90                             rts
 *--------------------------------------
 CS.RUN.PRINT.SRCPATH
-				ldy #hSrcBasePath
-				lda (pData),y
-				>SYSCALL GetMemPtr
-				>PUSHYA
-				>PUSHBI 0
-				>SYSCALL PrintF
-				rts
+                                ldy #hSrcBasePath
+                                lda (pData),y
+                                >SYSCALL GetMemPtr
+                                >PUSHYA
+                                >PUSHBI 0
+                                >SYSCALL PrintF
+                                rts
 *--------------------------------------
 CS.RUN.PushUidGid
-				ldy #S.STAT.UID
-				lda (ZPFileStat),y
-				>PUSHA
-				>PUSHW ZPPWBuf
-				>SYSCALL GetPWUID
-				bcs .2
+                                ldy #S.STAT.UID
+                                lda (ZPFileStat),y
+                                >PUSHA
+                                >PUSHW ZPPWBuf
+                                >SYSCALL GetPWUID
+                                bcs .2
 
-				>PUSHEA.G USER
-				jsr CS.RUN.PushUidGidStr
-				bra .3
+                                >PUSHEA.G USER
+                                jsr CS.RUN.PushUidGidStr
+                                bra .3
 
-.2				>PUSHEA.G USER
-				>PUSHW L.FMT.int16
+.2                              >PUSHEA.G USER
+                                >PUSHW L.FMT.int16
 
-				ldy #S.STAT.UID+1
-				lda (ZPFileStat),y
-				>PUSHA
-				dey
-				lda (ZPFileStat),y
-				>PUSHA
-				>PUSHBI 2
-				>SYSCALL SPrintF
+                                ldy #S.STAT.UID+1
+                                lda (ZPFileStat),y
+                                >PUSHA
+                                dey
+                                lda (ZPFileStat),y
+                                >PUSHA
+                                >PUSHBI 2
+                                >SYSCALL SPrintF
 
-.3				ldy #S.STAT.GID
-				lda (ZPFileStat),y
-				>PUSHA
-				>PUSHW ZPPWBuf
-				>SYSCALL GetGRGID
-				bcs .5
+.3                              ldy #S.STAT.GID
+                                lda (ZPFileStat),y
+                                >PUSHA
+                                >PUSHW ZPPWBuf
+                                >SYSCALL GetGRGID
+                                bcs .5
 
-				>PUSHEA.G GROUP
-				jsr CS.RUN.PushUidGidStr
+                                >PUSHEA.G GROUP
+                                jsr CS.RUN.PushUidGidStr
 
-				bra .8
+                                bra .8
 
-.5				>PUSHEA.G GROUP
-				>PUSHW L.FMT.int16
+.5                              >PUSHEA.G GROUP
+                                >PUSHW L.FMT.int16
 
-				ldy #S.STAT.GID+1
-				lda (ZPFileStat),y
-				>PUSHA
-				dey
-				lda (ZPFileStat),y
-				>PUSHA
-				>PUSHBI 2
-				>SYSCALL SPrintF
+                                ldy #S.STAT.GID+1
+                                lda (ZPFileStat),y
+                                >PUSHA
+                                dey
+                                lda (ZPFileStat),y
+                                >PUSHA
+                                >PUSHBI 2
+                                >SYSCALL SPrintF
 
-.8				>PUSHEA.G USER
-				>PUSHEA.G GROUP
-				clc
-				rts
+.8                              >PUSHEA.G USER
+                                >PUSHEA.G GROUP
+                                clc
+                                rts
 
 CS.RUN.PushUidGidStr
-				>PUSHW L.FMT.string6
-				>PUSHW ZPPWBuf
-				>PUSHBI 2
-				>SYSCALL SPrintF
-				rts
+                                >PUSHW L.FMT.string6
+                                >PUSHW ZPPWBuf
+                                >PUSHBI 2
+                                >SYSCALL SPrintF
+                                rts
 *--------------------------------------
 CS.RUN.PUSHDATES
-				ldy #TIME.Mod-1			Set NODATE as default
-				jsr CS.RUN.NODATES.INIT
+                                ldy #TIME.Mod-1                 Set NODATE as default
+                                jsr CS.RUN.NODATES.INIT
 
-				ldy #TIME.Create-1		Set NODATE as default
-				jsr CS.RUN.NODATES.INIT
+                                ldy #TIME.Create-1              Set NODATE as default
+                                jsr CS.RUN.NODATES.INIT
 
-				ldy #S.STAT.MTIME+S.TIME.MONTH
-				lda (ZPFileStat),y
-				beq .1					Month=0.....invalid date/time
+                                ldy #S.STAT.MTIME+S.TIME.MONTH
+                                lda (ZPFileStat),y
+                                beq .1                                  Month=0.....invalid date/time
 
-				>PUSHEA.G TIME.Mod
+                                >PUSHEA.G TIME.Mod
 
-				lda ZPFileStat
-				clc
-				adc #S.STAT.MTIME
-				tay
-				lda ZPFileStat+1
-				adc #0
-				jsr CS.RUN.DATEFMT.SELECT
-				>SYSCALL StrFTime
+                                lda ZPFileStat
+                                clc
+                                adc #S.STAT.MTIME
+                                tay
+                                lda ZPFileStat+1
+                                adc #0
+                                jsr CS.RUN.DATEFMT.SELECT
+                                >SYSCALL StrFTime
 
-.1				ldy #S.STAT.CTIME+S.TIME.MONTH
-				lda (ZPFileStat),y
-				beq .2					Month=0.....invalid date/time
+.1                              ldy #S.STAT.CTIME+S.TIME.MONTH
+                                lda (ZPFileStat),y
+                                beq .2                                  Month=0.....invalid date/time
 
-				>PUSHEA.G TIME.Create
+                                >PUSHEA.G TIME.Create
 
-				lda ZPFileStat
-				clc
-				adc #S.STAT.CTIME
-				tay
-				lda ZPFileStat+1
-				adc #0
-				jsr CS.RUN.DATEFMT.SELECT
-				>SYSCALL StrFTime
+                                lda ZPFileStat
+                                clc
+                                adc #S.STAT.CTIME
+                                tay
+                                lda ZPFileStat+1
+                                adc #0
+                                jsr CS.RUN.DATEFMT.SELECT
+                                >SYSCALL StrFTime
 
-.2				>PUSHEA.G TIME.Mod
-				>PUSHEA.G TIME.Create
-				rts
+.2                              >PUSHEA.G TIME.Mod
+                                >PUSHEA.G TIME.Create
+                                rts
 *--------------------------------------
 CS.RUN.NODATES.INIT
-				ldx #$ff
+                                ldx #$ff
 
-.1				inx
-				iny
-				lda MSG.NODATE,x
-				sta (pData),y
-				bne .1
+.1                              inx
+                                iny
+                                lda MSG.NODATE,x
+                                sta (pData),y
+                                bne .1
 
-				rts
+                                rts
 *--------------------------------------
 CS.RUN.DATEFMT.SELECT
-				>STYA ZPPtr1
+                                >STYA ZPPtr1
 
-				ldy #S.TIME.CENTURY
-				lda (ZPPtr1),y
-				ldy #TIME.SysTime+S.TIME.CENTURY
-				cmp (pData),y
-				bne .9
+                                ldy #S.TIME.CENTURY
+                                lda (ZPPtr1),y
+                                ldy #TIME.SysTime+S.TIME.CENTURY
+                                cmp (pData),y
+                                bne .9
 
-				ldy #S.TIME.YEAR
-				lda (ZPPtr1),y
-				ldy #TIME.SysTime+S.TIME.YEAR
-				cmp (pData),y
-				bne .9
+                                ldy #S.TIME.YEAR
+                                lda (ZPPtr1),y
+                                ldy #TIME.SysTime+S.TIME.YEAR
+                                cmp (pData),y
+                                bne .9
 
-				ldy #S.TIME.MONTH
-				lda (ZPPtr1),y
-				ldy #TIME.SysTime+S.TIME.MONTH
-				cmp (pData),y
-				bne .9
+                                ldy #S.TIME.MONTH
+                                lda (ZPPtr1),y
+                                ldy #TIME.SysTime+S.TIME.MONTH
+                                cmp (pData),y
+                                bne .9
 
-				ldy #S.TIME.DAY
-				lda (ZPPtr1),y
-				ldy #TIME.SysTime+S.TIME.DAY
-				cmp (pData),y
-				bne .9
+                                ldy #S.TIME.DAY
+                                lda (ZPPtr1),y
+                                ldy #TIME.SysTime+S.TIME.DAY
+                                cmp (pData),y
+                                bne .9
 
-.8				>PUSHW L.FMT.Time
-				>PUSHW ZPPtr1
-				rts
+.8                              >PUSHW L.FMT.Time
+                                >PUSHW ZPPtr1
+                                rts
 
-.9				>PUSHW L.FMT.Date
-				>PUSHW ZPPtr1
-				rts
+.9                              >PUSHW L.FMT.Date
+                                >PUSHW ZPPtr1
+                                rts
 *--------------------------------------
 CS.RUN.UpdateColCnt
-				inc ColCount
-				lda ColCount
-				cmp #MAX.COL
-				bne CS.RUN.NewLine.8
+                                inc ColCount
+                                lda ColCount
+                                cmp #MAX.COL
+                                bne CS.RUN.NewLine.8
 
-				stz ColCount
-				
-				bra CS.RUN.NewLine.1
+                                stz ColCount
+                                
+                                bra CS.RUN.NewLine.1
 *--------------------------------------
 CS.RUN.ENTER.MSG
-				>PUSHW L.MSG.ENTER
-				ldy #hSrcBasePath
-				lda (pData),y
-				>SYSCALL GetMemPtr
-				>PUSHYA
-				>PUSHBI 2
+                                >PUSHW L.MSG.ENTER
+                                ldy #hSrcBasePath
+                                lda (pData),y
+                                >SYSCALL GetMemPtr
+                                >PUSHYA
+                                >PUSHBI 2
 
-				>SYSCALL PrintF
-				bcc	CS.RUN.NewLine.1
-				rts
+                                >SYSCALL PrintF
+                                bcc CS.RUN.NewLine.1
+                                rts
 *--------------------------------------
-CS.RUN.NewLine	lda ColCount
-				beq CS.RUN.NewLine.8
+CS.RUN.NewLine  lda ColCount
+                                beq CS.RUN.NewLine.8
 CS.RUN.NewLine.1
-				lda #C.CR
-				>SYSCALL PutChar
+                                lda #C.CR
+                                >SYSCALL PutChar
 
-				lda #C.LF
-				>SYSCALL PutChar
+                                lda bIsTTY
+                                beq CS.RUN.NewLine.8
+
+                                lda #C.LF
+                                >SYSCALL PutChar
 
 CS.RUN.NewLine.8
-				clc
-				rts
+                                clc
+                                rts
 *--------------------------------------
-CS.DOEVENT		sec
-				rts
+CS.RUN.ISATTY           ldy #S.PS.hStdOut
+                        lda (pPS),y
+                        tax
+                        lsr
+                        bcc .9
+                        lda Nod.Table.hFD-2,x
+                        >SYSCALL GetMemPtr
+                        >STYA ZPPtr1
+                        lda (ZPPtr1)
+                        beq .9
+                        inc bIsTTY
+.9                      rts
 *--------------------------------------
-CS.QUIT			jsr LeaveSubDir
-				bcc CS.QUIT
-
-				ldy #hFilter
-				jsr .7
-
-				ldy #hPWBuf
-				jsr .7
-
-				ldy #hLineBuf
-
-.7				lda (pData),y
-				beq .8
-
-				>SYSCALL FreeMem
-
-.8				clc
-				rts
+CS.DOEVENT              sec
+                                rts
 *--------------------------------------
-FileType2PSTR	ldy #0
+CS.QUIT                 jsr LeaveSubDir
+                                bcc CS.QUIT
 
-.1				cmp PRODOS.FT.HEX,y
-				beq .8
+                                ldy #hFilter
+                                jsr .7
 
-				iny
-				cpy #PRODOS.FT.TXT-PRODOS.FT.HEX
-				bne .1
+                                ldy #hPWBuf
+                                jsr .7
 
-				pha
-				lsr
-				lsr
-				lsr
-				lsr
-				ora #$30
-				cmp #'9'+1
-				bcc .2
+                                ldy #hLineBuf
 
-				adc #6
+.7                              lda (pData),y
+                                beq .8
 
-.2				sta PRODOS.FT.DFLT+1
-				pla
-				and #$0F
-				ora #$30
-				cmp #'9'+1
-				bcc .3
+                                >SYSCALL FreeMem
 
-				adc #6
-
-.3				sta PRODOS.FT.DFLT+2
-
-.8				tya
-				asl
-				asl						CC
-				adc L.PRODOS.FT.TXT
-				tay
-
-				lda L.PRODOS.FT.TXT+1
-				adc #0
-
-				rts
+.8                              clc
+                                rts
 *--------------------------------------
-Mod2CSTR		ldy #S.STAT.MODE+1
-				lda (ZPFileStat),y
-				lsr
-				php						C = RU
+FileType2PSTR   ldy #0
 
-				lsr
-				lsr
-				lsr
-				tax
-				lda TYPES,x
-				>STA.G MOD
+.1                              cmp PRODOS.FT.HEX,y
+                                beq .8
 
-				plp
+                                iny
+                                cpy #PRODOS.FT.TXT-PRODOS.FT.HEX
+                                bne .1
 
-				ldy #S.STAT.MODE
-				lda (ZPFileStat),y
+                                pha
+                                lsr
+                                lsr
+                                lsr
+                                lsr
+                                ora #$30
+                                cmp #'9'+1
+                                bcc .2
 
-				ldy #MOD+1
-				ldx #8
+                                adc #6
 
-.1				pha
-				lda #'-'
-				bcc .2
+.2                              sta PRODOS.FT.DFLT+1
+                                pla
+                                and #$0F
+                                ora #$30
+                                cmp #'9'+1
+                                bcc .3
 
-				lda ACCESS,x
+                                adc #6
 
-.2				sta (pData),y
+.3                              sta PRODOS.FT.DFLT+2
 
-				iny
-				pla
-				asl
+.8                              tya
+                                asl
+                                asl                                             CC
+                                adc L.PRODOS.FT.TXT
+                                tay
 
-				dex
-				bpl .1
+                                lda L.PRODOS.FT.TXT+1
+                                adc #0
 
-				>PUSHEA.G MOD
-				rts
+                                rts
 *--------------------------------------
-				.INB usr/src/shared/x.fileenum.s
+Mod2CSTR                ldy #S.STAT.MODE+1
+                                lda (ZPFileStat),y
+                                lsr
+                                php                                             C = RU
+
+                                lsr
+                                lsr
+                                lsr
+                                tax
+                                lda TYPES,x
+                                >STA.G MOD
+
+                                plp
+
+                                ldy #S.STAT.MODE
+                                lda (ZPFileStat),y
+
+                                ldy #MOD+1
+                                ldx #8
+
+.1                              pha
+                                lda #'-'
+                                bcc .2
+
+                                lda ACCESS,x
+
+.2                              sta (pData),y
+
+                                iny
+                                pla
+                                asl
+
+                                dex
+                                bpl .1
+
+                                >PUSHEA.G MOD
+                                rts
+*--------------------------------------
+                                .INB usr/src/shared/x.fileenum.s
 *--------------------------------------
 CS.END
 *--------------------------------------
-OptionList		.AS "ACFLRacflr"
-OptionVars		.DA #bAllmostAll,#bColumn,#bFullPath,#bLong,#bRecurse,#bAllmostAll,#bColumn,#bFullPath,#bLong,#bRecurse
+OptionList              .AS "ACFLRacflr"
+OptionVars              .DA #bAllmostAll,#bColumn,#bFullPath,#bLong,#bRecurse,#bAllmostAll,#bColumn,#bFullPath,#bLong,#bRecurse
 *--------------------------------------
 MSG.USAGE       .AS "Usage : LS [-A] [-C] [-F] [-L] [-R] [filespec]\r\n"
                 .AS "   -A : Show dot files\r\n"
@@ -811,50 +830,50 @@ MSG.USAGE       .AS "Usage : LS [-A] [-C] [-F] [-L] [-R] [filespec]\r\n"
                 .AS "   -F : Show full paths\r\n"
                 .AS "   -L : Use long listing format\r\n"
                 .AZ "   -R : Recursively list subdirectories\r\n"
-MSG.REGEXT		.AZ "%s %6s %6s %10u %s %s %s %H %s"
-MSG.REG			.AZ "%19s"
-MSG.DIREXT		.AZ "%s %6s %6s            %s %s  <dir>   %s"
-MSG.DIR			.AZ "\e[32m%s/\e[0m"
-MSG.BDEVEXT		.AZ "/%15s s%dd%d Blocks Used:%5D Total:%5D"
-MSG.BDEV		.AZ "\e[32m%s/\e[0m"
-MSG.ENTER		.AZ "Directory:%s"
+MSG.REGEXT              .AZ "%s %6s %6s %10u %s %s %s %H %s"
+MSG.REG                 .AZ "%19s"
+MSG.DIREXT              .AZ "%s %6s %6s            %s %s  <dir>   %s"
+MSG.DIR                 .AZ "\e[32m%s/\e[0m"
+MSG.BDEVEXT             .AZ "/%15s s%dd%d Blocks Used:%5D Total:%5D"
+MSG.BDEV                .AZ "\e[32m%s/\e[0m"
+MSG.ENTER               .AZ "Directory:%s"
 *--------------------------------------
-PRODOS.FT.HEX	.HS 0406FAFCFDE2CBCCCFFF
-PRODOS.FT.TXT	.AZ "txt"
-				.AZ "bin"
-				.AZ "asm"
-				.AZ "bas"
-				.AZ "var"
-				.AZ "atk"
-				.AZ "pix"
-				.AZ "fon"
-				.AZ "pak"
-				.AZ "sys"
-PRODOS.FT.DFLT	.AZ "$  "
-MSG.NODATE		.AZ "<no-date>"
-FMT.Date		.AZ "%d-%b-%y"
-FMT.Time		.AZ "%H:%M:%S "
-FMT.string6		.AZ "%6s"
-FMT.int16		.AZ "%6D"
-TYPES			.AS "-dbclssp"
-ACCESS			.AS "xwrxwrxwr"
+PRODOS.FT.HEX   .HS 0406FAFCFDE2CBCCCFFF
+PRODOS.FT.TXT   .AZ "txt"
+                                .AZ "bin"
+                                .AZ "asm"
+                                .AZ "bas"
+                                .AZ "var"
+                                .AZ "atk"
+                                .AZ "pix"
+                                .AZ "fon"
+                                .AZ "pak"
+                                .AZ "sys"
+PRODOS.FT.DFLT  .AZ "$  "
+MSG.NODATE              .AZ "<no-date>"
+FMT.Date                .AZ "%d-%b-%y"
+FMT.Time                .AZ "%H:%M:%S "
+FMT.string6             .AZ "%6s"
+FMT.int16               .AZ "%6D"
+TYPES                   .AS "-dbclssp"
+ACCESS                  .AS "xwrxwrxwr"
 *--------------------------------------
-				.DUMMY
-				.OR 0
+                                .DUMMY
+                                .OR 0
 DS.START
-MOD				.BS 11					drwxrwxrwx0
-USER			.BS 7
-GROUP			.BS 7
+MOD                             .BS 11                                  drwxrwxrwx0
+USER                    .BS 7
+GROUP                   .BS 7
 
-TIME.Create		.BS 20
-TIME.Mod		.BS 20
-TIME.SysTime	.BS S.TIME
+TIME.Create             .BS 20
+TIME.Mod                .BS 20
+TIME.SysTime    .BS S.TIME
 
-hLineBuf		.BS 1
-hPWBuf			.BS 1
+hLineBuf                .BS 1
+hPWBuf                  .BS 1
 
-				.INB usr/src/shared/x.fileenum.g
-DS.END			.ED
+                                .INB usr/src/shared/x.fileenum.g
+DS.END                  .ED
 *--------------------------------------
 MAN
 SAVE usr/src/bin/ls.s

--- a/BIN/NL.S.txt
+++ b/BIN/NL.S.txt
@@ -1,0 +1,281 @@
+NEW
+  AUTO 3,1
+                                .LIST OFF
+                                .OP     65C02
+                                .OR     $2000
+                                .TF bin/nl
+*--------------------------------------
+                                .INB inc/macros.i
+                                .INB inc/a2osx.i
+                                .INB inc/kernel.i
+                                .INB inc/mli.i
+                                .INB inc/mli.e.i
+*--------------------------------------
+                                .DUMMY
+                                .OR ZPBIN
+ZS.START
+ArgIndex                .BS 1
+ArgPattern              .BS 1
+ZPPtr1                  .BS 2
+ZPBufPtr                .BS 2
+hFile                   .BS 1
+hBuf                    .BS 1
+char                    .BS 1
+LineCount               .BS 2
+bPause                  .BS 1
+bPipe                   .BS 1
+bIsTTY                  .BS 1
+bNewLine                .BS 1
+bDummy                  .BS 1
+
+ZS.END                  .ED
+*--------------------------------------
+*                       File Header (16 Bytes)
+*--------------------------------------
+CS.START                cld
+                        jmp (.1,x)
+                        .DA #$61                  6502,Level 1 (65c02)
+                        .DA #1                    BIN Layout Version 1
+                        .DA #0                    S.PS.F.EVENT
+                        .DA #0
+                        .DA CS.END-CS.START       Code Size (without Constants)
+                        .DA DS.END-DS.START       Data Segment Size
+                        .DA #16                   Stack Size
+                        .DA #ZS.END-ZS.START      Zero Page Size
+                        .DA 0
+*--------------------------------------
+* Relocation Table
+*--------------------------------------
+.1                      .DA CS.INIT
+                        .DA CS.RUN
+                        .DA CS.DOEVENT          
+                        .DA CS.QUIT
+L.MSG.USAGE             .DA MSG.USAGE
+L.MSG.CRLF              .DA MSG.CRLF
+L.MSG.LINENUM           .DA MSG.LINENUM
+                        .DA 0
+*--------------------------------------
+CS.INIT                 clc
+                        rts
+*--------------------------------------
+CS.RUN                  stz bPipe
+                        stz bIsTTY
+                        stz bNewLine
+                        inc bNewLine
+                        jsr CS.RUN.ISATTY
+                        jsr CS.RUN.CheckArgs
+                        bcs CS.RUN.LOOP.RTS
+
+                        stz LineCount
+                        stz LineCount+1
+                        inc LineCount
+
+CS.RUN.LOOP             lda bPipe                If reading from pipe
+                        bne .2                   No ^C/^S handling
+
+                        ldy #S.PS.hStdIn
+                        lda (pPS),y
+                        >SYSCALL FEOF
+                        bcs .9                   I/O Error
+
+                        tay
+                        bne .1                   No char
+
+                        >SYSCALL GetChar
+                        bcs .9                   I/O error
+                        cmp #$03                 Ctrl-C
+                        beq .9
+                        cmp #$13                 Ctrl-S
+                        bne .1
+                        
+                        lda bPause
+                        eor #$ff
+                        sta bPause
+                        bne CS.RUN.LOOP                        
+
+.1                      lda bPause
+                        bne CS.RUN.LOOP
+
+.2                      >SLEEP
+
+                        lda hFile
+                        >SYSCALL GetC
+                        bcs .7
+
+                        jsr CS.RUN.PRINTBYTE
+                        bra CS.RUN.LOOP
+
+.7                      cmp #MLI.E.EOF
+                        bne .9
+
+.8                      lda #0                     Exit with no Error
+
+.9                      sec
+CS.RUN.LOOP.RTS         rts
+*--------------------------------------
+CS.RUN.CheckArgs        jsr CS.RUN.NextArg
+                        bcs .4
+
+                        lda (ZPPtr1)
+                        cmp #'-'
+                        beq .1
+
+.11                     lda hFile
+                        bne .97
+
+                        >LDYA ZPPtr1
+                        jsr CS.RUN.OPEN
+                        bcs .9
+
+                        sta hFile
+                        bra CS.RUN.CheckArgs
+
+.1                      ldy #1 
+                        lda (ZPPtr1),y
+
+                        ldx #OptionList.Cnt-1
+
+.2                      cmp OptionList,x
+                        beq .3
+
+                        dex
+                        bpl .2
+
+                        bra .97
+
+.3                      txa
+                        lsr
+                        beq .98
+
+                        tax
+                        lda #$80
+                        sta bDummy-1,x 
+                        bra CS.RUN.CheckArgs
+                                
+.4                      lda hFile
+                        bne .80
+
+                        ldy #S.PS.hStdIn
+                        lda (pPS),y
+                        tax
+                                
+                        lsr
+                        bcs .97
+                                
+                        lda Nod.Table.hFD-2,x
+                        >SYSCALL GetMemPtr
+                        >STYA ZPPtr1
+                        lda (ZPPtr1)
+                        cmp #S.FD.T.PIPE
+                        bne .97
+                                
+                        ldy #S.PS.hStdIn
+                        lda (pPS),y
+                        sta hFile
+                        inc bPipe                        
+
+.80                     >LDYAI 256
+                        >SYSCALL GetMem
+                        bcs .9
+
+                        >STYA ZPBufPtr
+                        stx hBuf
+
+*                       clc
+
+.9                      rts
+
+.97                     lda #E.SYN
+
+.98                     pha
+                        >PUSHW L.MSG.USAGE
+                        >PUSHBI 0
+                        >SYSCALL PrintF
+                        pla
+                        sec
+                        rts
+*--------------------------------------
+CS.RUN.NextArg          inc ArgIndex
+                        lda ArgIndex
+                        >SYSCALL ArgV
+                        bcs .9
+
+                        >STYA ZPPtr1
+
+.9                      rts
+*--------------------------------------
+CS.RUN.OPEN             >PUSHYA
+                        >PUSHBI O.RDONLY+O.TEXT
+                        >PUSHBI S.FI.T.TXT
+                        >PUSHWZ                         Aux type
+                        >SYSCALL FOpen
+                        bcs .9
+                        sta hFile
+.9                      rts
+*--------------------------------------
+CS.RUN.ISATTY           ldy #S.PS.hStdOut
+                        lda (pPS),y
+                        tax
+                        lsr
+                        bcc .9
+                        lda Nod.Table.hFD-2,x
+                        >SYSCALL GetMemPtr
+                        >STYA ZPPtr1
+                        lda (ZPPtr1)
+                        beq .9
+                        inc bIsTTY
+.9                      rts
+*--------------------------------------
+CS.QUIT                 lda hFile
+                        beq .1
+                        >SYSCALL FClose
+.1                      lda hBuf
+                        beq .8
+                        >SYSCALL FreeMem
+.8                      clc
+                        rts
+*--------------------------------------
+CS.RUN.PRINTBYTE        pha
+                        lda bNewLine
+                        beq .2
+                        stz bNewLine
+                        >PUSHW L.MSG.LINENUM
+                        >PUSHW LineCount
+                        >PUSHBI 2
+                        >SYSCALL PrintF
+.2                      pla
+                        pha
+                        >SYSCALL PutChar
+                        pla
+                        cmp #C.CR
+                        bne .9
+                        lda bIsTTY
+                        beq .4
+                        lda #C.LF
+                        >SYSCALL PutChar
+.4                      inc bNewLine
+                        inc LineCount
+                        bne .9
+                        inc LineCount+1
+.9                      rts
+*--------------------------------------
+CS.DOEVENT              sec
+                        rts
+*--------------------------------------
+CS.END
+*--------------------------------------
+OptionList              .AS "x"
+OptionList.Cnt          .EQ *-OptionList
+*--------------------------------------
+MSG.USAGE               .AS "Usage : NL <File> or CMD|NL"
+MSG.CRLF                .AZ "\r\n"
+MSG.LINENUM             .AZ "%5D "
+*--------------------------------------
+                                .DUMMY
+                                .OR 0
+DS.START
+DS.END                  .ED
+*--------------------------------------
+MAN
+SAVE usr/src/bin/nl.s
+ASM

--- a/BIN/OD.S.txt
+++ b/BIN/OD.S.txt
@@ -1,0 +1,333 @@
+                                .LIST OFF
+                                .OP     65C02
+                                .OR     $2000
+                                .TF bin/od
+*--------------------------------------
+                                .INB inc/macros.i
+                                .INB inc/a2osx.i
+                                .INB inc/kernel.i
+                                .INB inc/mli.i
+                                .INB inc/mli.e.i
+*--------------------------------------
+                                .DUMMY
+                                .OR ZPBIN
+ZS.START
+ZPPtr1                  .BS 2
+ZPBufPtr                .BS 2
+ByteIndex               .BS 1
+ArgCount                .BS 1
+FileCount               .BS 1
+bPause                  .BS 1
+bDummy                  .BS 1
+bStdout                 .BS 1
+ArgIndex                .BS 1
+hBuf                    .BS 1
+hFile                   .BS 1
+ByteCount               .BS 3
+ZS.END                  .ED     
+*--------------------------------------
+*                       File Header (16 Bytes)
+*--------------------------------------
+CS.START                cld
+                        jmp (.1,x)
+                        .DA #$61                        6502,Level 1 (65c02)
+                        .DA #1                          BIN Layout Version 1
+                        .DA #S.PS.F.EVENT               S.PS.F
+                        .DA #0
+                        .DA CS.END-CS.START             CS
+                        .DA DS.END-DS.START             DS
+                        .DA #64                         SS
+                        .DA #ZS.END-ZS.START            Zero Page Size
+                        .DA 0
+*--------------------------------------
+* Relocation Table
+*--------------------------------------
+.1                              .DA CS.INIT
+                                .DA CS.RUN
+                                .DA CS.DOEVENT          
+                                .DA CS.QUIT
+L.MSG.USAGE                     .DA MSG.USAGE
+L.MSG.CRLF                      .DA MSG.CRLF
+L.MSG.INIT                      .DA MSG.INIT
+L.MSG.OFFSET                    .DA MSG.OFFSET
+L.MSG.HEXBYTE                   .DA MSG.HEXBYTE
+                                .DA 0
+*--------------------------------------
+CS.INIT                         clc
+                                rts
+*--------------------------------------
+CS.RUN                  
+.1                              stz bStdout
+                                stz ByteCount
+                                stz ByteCount+1
+                                stz ByteCount+2
+                   
+                                inc ArgCount
+                                lda ArgCount
+                                >SYSCALL ArgV
+                                bcs .7
+
+                                >STYA ZPPtr1
+
+                                lda (ZPPtr1)
+                                cmp #'-'
+                                bne .4
+
+                                ldy #1 
+                                lda (ZPPtr1),y
+
+                                ldx #OptionList.Cnt-1
+                                
+.2                              cmp OptionList,x
+                                beq .3
+
+                                dex
+                                bpl .2
+
+.99                             >PUSHW L.MSG.USAGE
+                                >PUSHBI 0
+                                >SYSCALL PrintF
+                                lda #E.SYN
+                                sec
+.9                              rts
+
+.3                              ldy OptionVars,x
+                                lda #$80
+                                sta 0,y
+                                bra .1
+
+.4                              inc FileCount
+                                bra .1                scan for any other args
+
+.7                              lda FileCount
+                                beq .99
+
+                                >LDYAI 256
+                                >SYSCALL GetMem
+                                bcs .9
+
+                                >STYA ZPBufPtr
+                                stx hBuf
+                                
+                                ldy #S.PS.hStdOut
+                                lda (pPS),y
+
+                                tax
+                                
+                                lsr
+                                bcc CS.RUN.LOOP
+                                
+                                lda Nod.Table.hFD-2,x
+                                >SYSCALL GetMemPtr
+                                >STYA ZPPtr1
+
+                                lda (ZPPtr1)
+
+                                beq CS.RUN.LOOP
+
+                                cmp #S.FD.T.PIPE
+                                beq CS.RUN.LOOP
+
+                                lda #$ff
+                                sta bStdout
+                        
+                                >PUSHW L.MSG.INIT
+                                >PUSHBI 0
+                                >SYSCALL PrintF
+*--------------------------------------
+CS.RUN.LOOP                     ldy #S.PS.hStdIn
+                                lda (pPS),y
+                                >SYSCALL FEOF
+                                bcs .90                         IO error
+
+                                tay
+                                bne .10                         no char
+
+                                >SYSCALL GetChar
+                                bcs .9                          IO error
+
+                                cmp #$03                        Ctrl-C
+                                beq .9                          Abort....
+
+                                cmp #$13                        Ctrl-S
+                                bne .10
+
+                                lda bPause
+                                eor #$ff
+                                sta bPause
+                                bne CS.RUN.LOOP
+
+.10                             lda bPause
+                                bne CS.RUN.LOOP                 Pause...
+
+.11                             lda hFile
+                                bne .2
+
+.1                              inc ArgIndex
+                                lda ArgIndex
+                                >SYSCALL ArgV
+                                bcs .99                 No more arg...the end!
+
+                                >STYA ZPPtr1
+                                lda (ZPPtr1)
+                                cmp #'-'
+                                beq .1                  An option, skip...
+
+                                >LDYA ZPPtr1
+                                jsr CS.RUN.OPEN
+.90                             bcs .9
+
+                                sta hFile
+
+.2                              lda hFile
+                                >SYSCALL GetC
+                                bcs .7
+
+                                jsr CS.RUN.PRINTBYTE
+ 
+                                bra CS.RUN.LOOP
+
+.7                              cmp #MLI.E.EOF
+                                bne .9
+
+                                jsr CS.RUN.CLOSE
+                                jsr CS.RUN.FINISHUP
+                                jmp CS.RUN.LOOP
+
+.99                             lda #0                    Exit with no Error
+.9                              sec
+                                rts
+*--------------------------------------
+CS.RUN.OPEN                     >PUSHYA
+                                >PUSHBI O.RDONLY+O.TEXT
+                                >PUSHBI S.FI.T.TXT
+                                >PUSHWZ                         Aux type
+                                >SYSCALL FOpen
+                                rts
+*--------------------------------------
+CS.RUN.PRINTBYTE                pha                           Char is in A
+
+                                lda ByteCount                 Divisible by 16
+                                and #$0f
+                                pha
+                                bne .2
+
+                                >PUSHW L.MSG.OFFSET           Print offset
+                                lda ByteCount+2
+                                >PUSHA
+                                lda ByteCount+1
+                                >PUSHA
+                                lda ByteCount
+                                >PUSHA
+                                >PUSHBI 3
+                                >SYSCALL PrintF
+
+.2                              ply                           Offset mod 16
+                                pla                           Character
+                                pha
+                                sta (ZPPtr1),y
+                                
+                                >PUSHW L.MSG.HEXBYTE
+                                pla
+                                >PUSHA
+                                >PUSHBI 1
+                                >SYSCALL PrintF
+
+.6                              lda ByteCount
+                                and #$0f
+                                cmp #$0f
+                                bne .8
+
+                                jsr CS.RUN.PRINTASCII
+
+.8                              inc ByteCount
+                                bne .9
+                                inc ByteCount+1
+                                bne .9
+                                inc ByteCount+2
+
+.9                              rts
+*--------------------------------------
+CS.RUN.PRINTASCII               lda ByteCount
+                                and #$0f
+                                sta bDummy
+
+                                lda #'>'
+                                >SYSCALL PutChar
+
+                                ldy #$00
+.7                              lda (ZPPtr1),y
+                                phy
+                                cmp #C.SPACE
+                                bcs .8
+                                lda #'.'
+
+.8                              >SYSCALL PutChar
+                                ply
+                                iny
+                                cpy bDummy
+                                bne .7
+
+                                lda #'<'
+                                >SYSCALL PutChar
+
+                                lda #C.CR
+                                >SYSCALL PutChar
+                                lda bStdout
+                                beq .9
+                                lda #C.LF
+                                >SYSCALL PutChar
+
+.9                              rts
+*--------------------------------------
+CS.RUN.FINISHUP                 lda ByteCount
+                                and #$0f
+                                bne .1
+                                rts
+.1                              pha
+                                lda #' '
+                                >SYSCALL PutChar
+                                lda #' '
+                                >SYSCALL PutChar
+                                lda #' ' 
+                                >SYSCALL PutChar
+                                pla
+                                inc
+                                cmp #$10
+                                bne .1
+.2                              jsr CS.RUN.PRINTASCII
+                                rts
+*--------------------------------------
+CS.QUIT                         lda hBuf
+                                beq CS.RUN.CLOSE
+                                >SYSCALL FreeMem
+
+CS.RUN.CLOSE                    lda hFile
+                                beq .8
+
+                                stz hFile
+
+                                >SYSCALL FClose
+.8                              clc
+                                rts
+*--------------------------------------
+CS.DOEVENT                      sec
+                                rts
+*--------------------------------------
+CS.END
+*--------------------------------------
+OptionList              .AS "x"
+OptionList.Cnt          .EQ *-OptionList
+OptionVars              .DA #bDummy
+*--------------------------------------
+MSG.USAGE               .AS "Usage : CAT File1 [File2...]"
+MSG.CRLF                .AZ "\r\n"
+MSG.INIT                .AZ "\e[?7h"                    Enable Line Wrap
+MSG.OFFSET              .AZ "%h%h%h "
+MSG.HEXBYTE             .AZ "%h "
+*--------------------------------------
+                                .DUMMY
+                                .OR 0
+DS.START
+DS.END                  .ED
+*--------------------------------------

--- a/BIN/OD.S.txt
+++ b/BIN/OD.S.txt
@@ -1,3 +1,5 @@
+NEW
+  AUTO 3,1
                                 .LIST OFF
                                 .OP     65C02
                                 .OR     $2000
@@ -22,6 +24,7 @@ char                    .BS 1
 ByteCount               .BS 3
 bPause                  .BS 1
 bPipe                   .BS 1
+bIsTTY                  .BS 1
 bTemp                   .BS 1
 bDummy                  .BS 1
 
@@ -57,6 +60,8 @@ CS.INIT                 clc
                         rts
 *--------------------------------------
 CS.RUN                  stz bPipe
+                        stz bIsTTY
+                        jsr CS.RUN.ISATTY
                         jsr CS.RUN.CheckArgs
                         bcs CS.RUN.LOOP.RTS
 
@@ -209,6 +214,19 @@ CS.RUN.OPEN             >PUSHYA
                         sta hFile
 .9                      rts
 *--------------------------------------
+CS.RUN.ISATTY           ldy #S.PS.hStdOut
+                        lda (pPS),y
+                        tax
+                        lsr
+                        bcc .9
+                        lda Nod.Table.hFD-2,x
+                        >SYSCALL GetMemPtr
+                        >STYA ZPPtr1
+                        lda (ZPPtr1)
+                        beq .9
+                        inc bIsTTY
+.9                      rts
+*--------------------------------------
 CS.QUIT                 lda hFile
                         beq .1
                         >SYSCALL FClose
@@ -287,6 +305,8 @@ CS.RUN.PRINTASCII
 
                 lda #C.CR
                 >SYSCALL PutChar
+                lda bIsTTY
+                beq .9
                 lda #C.LF
                 >SYSCALL PutChar
 .9              rts
@@ -328,3 +348,6 @@ MSG.HEXBYTE             .AZ "%h "
 DS.START
 DS.END                  .ED
 *--------------------------------------
+MAN
+SAVE usr/src/bin/od.s
+ASM

--- a/BIN/OD.S.txt
+++ b/BIN/OD.S.txt
@@ -20,6 +20,8 @@ hFile                   .BS 1
 hBuf                    .BS 1
 char                    .BS 1
 ByteCount               .BS 3
+bPause                  .BS 1
+bPipe                   .BS 1
 bTemp                   .BS 1
 bDummy                  .BS 1
 
@@ -54,14 +56,41 @@ L.MSG.HEXBYTE           .DA MSG.HEXBYTE
 CS.INIT                 clc
                         rts
 *--------------------------------------
-CS.RUN                  jsr CS.RUN.CheckArgs
+CS.RUN                  stz bPipe
+                        jsr CS.RUN.CheckArgs
                         bcs CS.RUN.LOOP.RTS
 
                         stz ByteCount
                         stz ByteCount+1
                         stz ByteCount+2
 
-CS.RUN.LOOP             >SLEEP
+CS.RUN.LOOP             lda bPipe                If reading from pipe
+                        bne .2                   No ^C/^S handling
+
+                        ldy #S.PS.hStdIn
+                        lda (pPS),y
+                        >SYSCALL FEOF
+                        bcs .9                   I/O Error
+
+                        tay
+                        bne .1                   No char
+
+                        >SYSCALL GetChar
+                        bcs .9                   I/O error
+                        cmp #$03                 Ctrl-C
+                        beq .9
+                        cmp #$13                 Ctrl-S
+                        bne .1
+                        
+                        lda bPause
+                        eor #$ff
+                        sta bPause
+                        bne CS.RUN.LOOP                        
+
+.1                      lda bPause
+                        bne CS.RUN.LOOP
+
+.2                      >SLEEP
 
                         lda hFile
                         >SYSCALL GetC
@@ -139,6 +168,7 @@ CS.RUN.CheckArgs        jsr CS.RUN.NextArg
                         ldy #S.PS.hStdIn
                         lda (pPS),y
                         sta hFile
+                        inc bPipe                        
 
 .80                     >LDYAI 256
                         >SYSCALL GetMem
@@ -238,9 +268,12 @@ CS.RUN.PRINTASCII
                 ldy #$00
 .7              lda (ZPBufPtr),y
                 phy
+                cmp #$7f
+                bcs .75                  Character >= $7f
                 cmp #C.SPACE
-                bcs .8
-                lda #'.'
+                bcc .75                  Character < Space
+                bra .8
+.75             lda #'.'
 
 .8              >SYSCALL PutChar
                 ply

--- a/BIN/OD.S.txt
+++ b/BIN/OD.S.txt
@@ -12,317 +12,281 @@
                                 .DUMMY
                                 .OR ZPBIN
 ZS.START
+ArgIndex                .BS 1
+ArgPattern              .BS 1
 ZPPtr1                  .BS 2
 ZPBufPtr                .BS 2
-ByteIndex               .BS 1
-ArgCount                .BS 1
-FileCount               .BS 1
-bPause                  .BS 1
-bDummy                  .BS 1
-bStdout                 .BS 1
-ArgIndex                .BS 1
-hBuf                    .BS 1
 hFile                   .BS 1
+hBuf                    .BS 1
+char                    .BS 1
 ByteCount               .BS 3
-ZS.END                  .ED     
+bTemp                   .BS 1
+bDummy                  .BS 1
+
+ZS.END                  .ED
 *--------------------------------------
 *                       File Header (16 Bytes)
 *--------------------------------------
 CS.START                cld
                         jmp (.1,x)
-                        .DA #$61                        6502,Level 1 (65c02)
-                        .DA #1                          BIN Layout Version 1
-                        .DA #S.PS.F.EVENT               S.PS.F
+                        .DA #$61                  6502,Level 1 (65c02)
+                        .DA #1                    BIN Layout Version 1
+                        .DA #0                    S.PS.F.EVENT
                         .DA #0
-                        .DA CS.END-CS.START             CS
-                        .DA DS.END-DS.START             DS
-                        .DA #64                         SS
-                        .DA #ZS.END-ZS.START            Zero Page Size
+                        .DA CS.END-CS.START       Code Size (without Constants)
+                        .DA DS.END-DS.START       Data Segment Size
+                        .DA #16                   Stack Size
+                        .DA #ZS.END-ZS.START      Zero Page Size
                         .DA 0
 *--------------------------------------
 * Relocation Table
 *--------------------------------------
-.1                              .DA CS.INIT
-                                .DA CS.RUN
-                                .DA CS.DOEVENT          
-                                .DA CS.QUIT
-L.MSG.USAGE                     .DA MSG.USAGE
-L.MSG.CRLF                      .DA MSG.CRLF
-L.MSG.INIT                      .DA MSG.INIT
-L.MSG.OFFSET                    .DA MSG.OFFSET
-L.MSG.HEXBYTE                   .DA MSG.HEXBYTE
-                                .DA 0
+.1                      .DA CS.INIT
+                        .DA CS.RUN
+                        .DA CS.DOEVENT          
+                        .DA CS.QUIT
+L.MSG.USAGE             .DA MSG.USAGE
+L.MSG.CRLF              .DA MSG.CRLF
+L.MSG.OFFSET            .DA MSG.OFFSET
+L.MSG.HEXBYTE           .DA MSG.HEXBYTE
+                        .DA 0
 *--------------------------------------
-CS.INIT                         clc
-                                rts
+CS.INIT                 clc
+                        rts
 *--------------------------------------
-CS.RUN                  
-.1                              stz bStdout
-                                stz ByteCount
-                                stz ByteCount+1
-                                stz ByteCount+2
-                   
-                                inc ArgCount
-                                lda ArgCount
-                                >SYSCALL ArgV
-                                bcs .7
+CS.RUN                  jsr CS.RUN.CheckArgs
+                        bcs CS.RUN.LOOP.RTS
 
-                                >STYA ZPPtr1
+                        stz ByteCount
+                        stz ByteCount+1
+                        stz ByteCount+2
 
-                                lda (ZPPtr1)
-                                cmp #'-'
-                                bne .4
+CS.RUN.LOOP             >SLEEP
 
-                                ldy #1 
-                                lda (ZPPtr1),y
+                        lda hFile
+                        >SYSCALL GetC
+                        bcs .7
 
-                                ldx #OptionList.Cnt-1
+                        jsr CS.RUN.PRINTBYTE
+                        bra CS.RUN.LOOP
+
+.7                      cmp #MLI.E.EOF
+                        bne .9
+
+                        jsr CS.RUN.FINISHUP
+
+.8                      lda #0                     Exit with no Error
+
+.9                      sec
+CS.RUN.LOOP.RTS         rts
+*--------------------------------------
+CS.RUN.CheckArgs        jsr CS.RUN.NextArg
+                        bcs .4
+
+                        lda (ZPPtr1)
+                        cmp #'-'
+                        beq .1
+
+.11                     lda hFile
+                        bne .97
+
+                        >LDYA ZPPtr1
+                        jsr CS.RUN.OPEN
+                        bcs .9
+
+                        sta hFile
+                        bra CS.RUN.CheckArgs
+
+.1                      ldy #1 
+                        lda (ZPPtr1),y
+
+                        ldx #OptionList.Cnt-1
+
+.2                      cmp OptionList,x
+                        beq .3
+
+                        dex
+                        bpl .2
+
+                        bra .97
+
+.3                      txa
+                        lsr
+                        beq .98
+
+                        tax
+                        lda #$80
+                        sta bDummy-1,x 
+                        bra CS.RUN.CheckArgs
                                 
-.2                              cmp OptionList,x
-                                beq .3
+.4                      lda hFile
+                        bne .80
 
-                                dex
-                                bpl .2
-
-.99                             >PUSHW L.MSG.USAGE
-                                >PUSHBI 0
-                                >SYSCALL PrintF
-                                lda #E.SYN
-                                sec
-.9                              rts
-
-.3                              ldy OptionVars,x
-                                lda #$80
-                                sta 0,y
-                                bra .1
-
-.4                              inc FileCount
-                                bra .1                scan for any other args
-
-.7                              lda FileCount
-                                beq .99
-
-                                >LDYAI 256
-                                >SYSCALL GetMem
-                                bcs .9
-
-                                >STYA ZPBufPtr
-                                stx hBuf
+                        ldy #S.PS.hStdIn
+                        lda (pPS),y
+                        tax
                                 
-                                ldy #S.PS.hStdOut
-                                lda (pPS),y
-
-                                tax
+                        lsr
+                        bcs .97
                                 
-                                lsr
-                                bcc CS.RUN.LOOP
+                        lda Nod.Table.hFD-2,x
+                        >SYSCALL GetMemPtr
+                        >STYA ZPPtr1
+                        lda (ZPPtr1)
+                        cmp #S.FD.T.PIPE
+                        bne .97
                                 
-                                lda Nod.Table.hFD-2,x
-                                >SYSCALL GetMemPtr
-                                >STYA ZPPtr1
+                        ldy #S.PS.hStdIn
+                        lda (pPS),y
+                        sta hFile
 
-                                lda (ZPPtr1)
+.80                     >LDYAI 256
+                        >SYSCALL GetMem
+                        bcs .9
 
-                                beq CS.RUN.LOOP
+                        >STYA ZPBufPtr
+                        stx hBuf
 
-                                cmp #S.FD.T.PIPE
-                                beq CS.RUN.LOOP
+*                       clc
 
-                                lda #$ff
-                                sta bStdout
-                        
-                                >PUSHW L.MSG.INIT
-                                >PUSHBI 0
-                                >SYSCALL PrintF
+.9                      rts
+
+.97                     lda #E.SYN
+
+.98                     pha
+                        >PUSHW L.MSG.USAGE
+                        >PUSHBI 0
+                        >SYSCALL PrintF
+                        pla
+                        sec
+                        rts
 *--------------------------------------
-CS.RUN.LOOP                     ldy #S.PS.hStdIn
-                                lda (pPS),y
-                                >SYSCALL FEOF
-                                bcs .90                         IO error
+CS.RUN.NextArg          inc ArgIndex
+                        lda ArgIndex
+                        >SYSCALL ArgV
+                        bcs .9
 
-                                tay
-                                bne .10                         no char
+                        >STYA ZPPtr1
 
-                                >SYSCALL GetChar
-                                bcs .9                          IO error
-
-                                cmp #$03                        Ctrl-C
-                                beq .9                          Abort....
-
-                                cmp #$13                        Ctrl-S
-                                bne .10
-
-                                lda bPause
-                                eor #$ff
-                                sta bPause
-                                bne CS.RUN.LOOP
-
-.10                             lda bPause
-                                bne CS.RUN.LOOP                 Pause...
-
-.11                             lda hFile
-                                bne .2
-
-.1                              inc ArgIndex
-                                lda ArgIndex
-                                >SYSCALL ArgV
-                                bcs .99                 No more arg...the end!
-
-                                >STYA ZPPtr1
-                                lda (ZPPtr1)
-                                cmp #'-'
-                                beq .1                  An option, skip...
-
-                                >LDYA ZPPtr1
-                                jsr CS.RUN.OPEN
-.90                             bcs .9
-
-                                sta hFile
-
-.2                              lda hFile
-                                >SYSCALL GetC
-                                bcs .7
-
-                                jsr CS.RUN.PRINTBYTE
- 
-                                bra CS.RUN.LOOP
-
-.7                              cmp #MLI.E.EOF
-                                bne .9
-
-                                jsr CS.RUN.CLOSE
-                                jsr CS.RUN.FINISHUP
-                                jmp CS.RUN.LOOP
-
-.99                             lda #0                    Exit with no Error
-.9                              sec
-                                rts
+.9                      rts
 *--------------------------------------
-CS.RUN.OPEN                     >PUSHYA
-                                >PUSHBI O.RDONLY+O.TEXT
-                                >PUSHBI S.FI.T.TXT
-                                >PUSHWZ                         Aux type
-                                >SYSCALL FOpen
-                                rts
+CS.RUN.OPEN             >PUSHYA
+                        >PUSHBI O.RDONLY+O.TEXT
+                        >PUSHBI S.FI.T.TXT
+                        >PUSHWZ                         Aux type
+                        >SYSCALL FOpen
+                        bcs .9
+                        sta hFile
+.9                      rts
 *--------------------------------------
-CS.RUN.PRINTBYTE                pha                           Char is in A
-
-                                lda ByteCount                 Divisible by 16
-                                and #$0f
-                                pha
-                                bne .2
-
-                                >PUSHW L.MSG.OFFSET           Print offset
-                                lda ByteCount+2
-                                >PUSHA
-                                lda ByteCount+1
-                                >PUSHA
-                                lda ByteCount
-                                >PUSHA
-                                >PUSHBI 3
-                                >SYSCALL PrintF
-
-.2                              ply                           Offset mod 16
-                                pla                           Character
-                                pha
-                                sta (ZPPtr1),y
-                                
-                                >PUSHW L.MSG.HEXBYTE
-                                pla
-                                >PUSHA
-                                >PUSHBI 1
-                                >SYSCALL PrintF
-
-.6                              lda ByteCount
-                                and #$0f
-                                cmp #$0f
-                                bne .8
-
-                                jsr CS.RUN.PRINTASCII
-
-.8                              inc ByteCount
-                                bne .9
-                                inc ByteCount+1
-                                bne .9
-                                inc ByteCount+2
-
-.9                              rts
+CS.QUIT                 lda hFile
+                        beq .1
+                        >SYSCALL FClose
+.1                      lda hBuf
+                        beq .8
+                        >SYSCALL FreeMem
+.8                      clc
+                        rts
 *--------------------------------------
-CS.RUN.PRINTASCII               lda ByteCount
-                                and #$0f
-                                sta bDummy
+CS.RUN.PRINTBYTE
+                pha                           Char is in A
 
-                                lda #'>'
-                                >SYSCALL PutChar
+                lda ByteCount                 Divisible by 16
+                and #$0f
+                sta bTemp
+                bne .2
 
-                                ldy #$00
-.7                              lda (ZPPtr1),y
-                                phy
-                                cmp #C.SPACE
-                                bcs .8
-                                lda #'.'
+                >PUSHW L.MSG.OFFSET           Print offset
+                lda ByteCount+2
+                >PUSHA
+                lda ByteCount+1
+                >PUSHA
+                lda ByteCount
+                >PUSHA
+                >PUSHBI 3
+                >SYSCALL PrintF
 
-.8                              >SYSCALL PutChar
-                                ply
-                                iny
-                                cpy bDummy
-                                bne .7
+.2              ldy bTemp                     Offset mod 16
+                pla                           Character
+                pha
+                sta (ZPBufPtr),y
+                
+                >PUSHW L.MSG.HEXBYTE
+                pla
+                >PUSHA
+                >PUSHBI 1
+                >SYSCALL PrintF
 
-                                lda #'<'
-                                >SYSCALL PutChar
+.6              inc ByteCount
+                bne .7
+                inc ByteCount+1
+                bne .7
+                inc ByteCount+2
 
-                                lda #C.CR
-                                >SYSCALL PutChar
-                                lda bStdout
-                                beq .9
-                                lda #C.LF
-                                >SYSCALL PutChar
+.7              lda bTemp
+                cmp #$0f
+                bne .9
 
-.9                              rts
+                jsr CS.RUN.PRINTASCII
+
+.9              rts
 *--------------------------------------
-CS.RUN.FINISHUP                 lda ByteCount
-                                and #$0f
-                                bne .1
-                                rts
-.1                              pha
-                                lda #' '
-                                >SYSCALL PutChar
-                                lda #' '
-                                >SYSCALL PutChar
-                                lda #' ' 
-                                >SYSCALL PutChar
-                                pla
-                                inc
-                                cmp #$10
-                                bne .1
-.2                              jsr CS.RUN.PRINTASCII
-                                rts
+CS.RUN.PRINTASCII
+                lda #'>'
+                >SYSCALL PutChar
+
+                ldy #$00
+.7              lda (ZPBufPtr),y
+                phy
+                cmp #C.SPACE
+                bcs .8
+                lda #'.'
+
+.8              >SYSCALL PutChar
+                ply
+                cpy bTemp
+                beq .85
+                iny
+                bra .7
+
+.85             lda #'<'
+                >SYSCALL PutChar
+
+                lda #C.CR
+                >SYSCALL PutChar
+                lda #C.LF
+                >SYSCALL PutChar
+.9              rts
 *--------------------------------------
-CS.QUIT                         lda hBuf
-                                beq CS.RUN.CLOSE
-                                >SYSCALL FreeMem
-
-CS.RUN.CLOSE                    lda hFile
-                                beq .8
-
-                                stz hFile
-
-                                >SYSCALL FClose
-.8                              clc
-                                rts
+CS.RUN.FINISHUP
+                lda ByteCount
+                and #$0f
+                bne .1
+                rts
+.1              pha
+                lda #' '
+                >SYSCALL PutChar
+                lda #' '
+                >SYSCALL PutChar
+                lda #' ' 
+                >SYSCALL PutChar
+                pla
+                inc
+                cmp #$10
+                bne .1
+.2              jsr CS.RUN.PRINTASCII
+                rts
 *--------------------------------------
-CS.DOEVENT                      sec
-                                rts
+CS.DOEVENT      sec
+                rts
 *--------------------------------------
 CS.END
 *--------------------------------------
 OptionList              .AS "x"
 OptionList.Cnt          .EQ *-OptionList
-OptionVars              .DA #bDummy
 *--------------------------------------
-MSG.USAGE               .AS "Usage : CAT File1 [File2...]"
+MSG.USAGE               .AS "Usage : OD <File> or CMD|OD"
 MSG.CRLF                .AZ "\r\n"
-MSG.INIT                .AZ "\e[?7h"                    Enable Line Wrap
 MSG.OFFSET              .AZ "%h%h%h "
 MSG.HEXBYTE             .AZ "%h "
 *--------------------------------------

--- a/BIN/SED.S.txt
+++ b/BIN/SED.S.txt
@@ -1,5 +1,3 @@
-NEW
-  AUTO 3,1
                                 .LIST OFF
                                 .OP     65C02
                                 .OR     $2000
@@ -253,6 +251,9 @@ CS.RUN.OPEN                     >PUSHYA
 CS.RUN.PRINT                    >LDYA ZPBufPtr
                                 >STYA ZPPtr1
 
+                                lda (ZPPtr1)            If null first time
+                                beq .8
+
 .1                              lda (ZPPtr1)
                                 beq .7                  EOL. No match.
 
@@ -290,11 +291,12 @@ CS.RUN.PRINT                    >LDYA ZPBufPtr
 
 * Hit EOL but not end of pattern, return
 .7                              jsr CS.RUN.NoMatch
-                                lda #C.CR
+.8                              lda #C.CR
                                 >SYSCALL PutChar
                                 lda #C.LF
                                 >SYSCALL PutChar
-                                clc
+
+.9                              clc
                                 rts
 *--------------------------------------
 CS.RUN.GotMatch                 phy
@@ -377,6 +379,3 @@ MSG.CRLF            .AZ "\r\n"
 DS.START
 DS.END                  .ED
 *--------------------------------------
-MAN
-SAVE usr/src/bin/sed.s
-ASM


### PR DESCRIPTION
Hi @burniouf 

Here is the pull request for my recent work on the utils.  It contains the following:

- Reworked version of `CAT.S.txt` which handles the EOL convention correctly.  `cat file > file` will always create an exact copy now.  The code checks if the output is to a TTY and only then outputs CRLF line endings.  The other modes of operation (-A, -N, etc) have been removed.  Utility is now much smaller <512 bytes.
- New utility `OD.S.txt` "octal dump" which (notwithstanding the name) actually does a hex dump.  This code also handles the EOF convention properly.
- Another new utility `NL.S.txt` "number lines".  Handles EOF convention properly.
- Fix to `SED.S.txt` to resolve buffer overrun when printing zero-length lines.  Ooops.

Shouldn't conflict with anything, so you should just be able to merge.